### PR TITLE
improve keyboard dismissal

### DIFF
--- a/src/app/(auth)/login.tsx
+++ b/src/app/(auth)/login.tsx
@@ -8,6 +8,8 @@ import {
   Platform,
   Alert,
   Image,
+  Keyboard,
+  Pressable,
 } from 'react-native';
 import { router } from 'expo-router';
 import { colors } from '../../constants/Colors';
@@ -169,7 +171,7 @@ export default function LoginScreen() {
       behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
       style={styles.container}
     >
-      <View style={styles.form}>
+      <Pressable style={styles.form} onPress={Keyboard.dismiss}>
         <View style={styles.logoContainer}>
           <Image source={require('../../assets/images/logo.png')} style={styles.logo} />
           <Text style={styles.stepnOut}>{t('Stepn Out')}</Text>
@@ -229,7 +231,7 @@ export default function LoginScreen() {
         >
           <Text style={styles.linkText}>{t("Don't have an account? Register")}</Text>
         </TouchableOpacity>
-      </View>
+      </Pressable>
     </KeyboardAvoidingView>
   );
 }

--- a/src/app/(auth)/register-profile.tsx
+++ b/src/app/(auth)/register-profile.tsx
@@ -8,6 +8,8 @@ import {
   Platform,
   Image,
   Alert,
+  Keyboard,
+  Pressable,
 } from "react-native";
 import { router, useLocalSearchParams } from "expo-router";
 import { colors } from "../../constants/Colors";
@@ -153,7 +155,7 @@ export default function RegisterProfileScreen() {
       behavior={Platform.OS === "ios" ? "padding" : "height"}
       style={styles.container}
     >
-      <View style={styles.form}>
+      <Pressable style={styles.form} onPress={Keyboard.dismiss}>
         <View style={styles.logoContainer}>
           <Image
             source={require("../../assets/images/logo.png")}
@@ -230,7 +232,7 @@ export default function RegisterProfileScreen() {
                 : t("Complete Registration")}
           </Text>
         </TouchableOpacity>
-      </View>
+      </Pressable>
     </KeyboardAvoidingView>
   );
 }

--- a/src/app/(auth)/register.tsx
+++ b/src/app/(auth)/register.tsx
@@ -7,6 +7,8 @@ import {
   KeyboardAvoidingView,
   Platform,
   Image,
+  Keyboard,
+  Pressable,
 } from 'react-native';
 import { router } from 'expo-router';
 import { colors } from '../../constants/Colors';
@@ -53,7 +55,7 @@ export default function RegisterScreen() {
       behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
       style={styles.container}
     >
-      <View style={styles.form}>
+      <Pressable style={styles.form} onPress={Keyboard.dismiss}>
         <View style={styles.logoContainer}>
           <Image source={require('../../assets/images/logo.png')} style={styles.logo} />
           <Text style={styles.stepnOut}>Stepn Out</Text>
@@ -94,7 +96,7 @@ export default function RegisterScreen() {
         >
           <Text style={styles.linkText}>{t('Already have an account? Log in')}</Text>
         </TouchableOpacity>
-      </View>
+      </Pressable>
     </KeyboardAvoidingView>
   );
 }

--- a/src/app/(tabs)/index.tsx
+++ b/src/app/(tabs)/index.tsx
@@ -232,6 +232,7 @@ const Home = () => {
           minIndexForVisible: 0,
         }}
         keyboardShouldPersistTaps="handled"
+        keyboardDismissMode="on-drag"
       >
         <Animated.View
           style={{

--- a/src/components/Challenge.tsx
+++ b/src/components/Challenge.tsx
@@ -11,7 +11,7 @@ import { KeyboardAvoidingView, Platform, Modal } from "react-native";
 import { Challenge } from "../types";
 import { Loader } from "../components/Loader";
 import ShareChallenge from "../components/ShareChallenge";
-import { View, StyleSheet } from "react-native";
+import { View, StyleSheet, Dimensions } from "react-native";
 import { PATRIZIO_ID } from "../constants/Patrizio";
 import { useLanguage } from "../contexts/LanguageContext";
 import { isVideo as isVideoUtil } from "../utils/utils";
@@ -387,6 +387,7 @@ export const ShareExperience: React.FC<ShareExperienceProps> = ({ challenge }) =
                 <TextInput
                   style={[shareStyles.textInput, { fontSize: 13, fontStyle: "italic" }]}
                   multiline
+                  scrollEnabled
                   placeholder={t("Just completed this week's challenge!")}
                   placeholderTextColor="#999"
                   onChangeText={setPostText}
@@ -693,6 +694,7 @@ const shareStyles = StyleSheet.create({
     borderWidth: 1,
     marginVertical: 10,
     minHeight: 80,
+    maxHeight: Dimensions.get("window").height * 0.15,
     minWidth: "100%",
     padding: 10,
     textAlignVertical: "top",

--- a/src/components/ChallengePage.tsx
+++ b/src/components/ChallengePage.tsx
@@ -79,6 +79,8 @@ export const ChallengePage: React.FC<ChallengePageProps> = ({ id }) => {
     <ScrollView
       style={styles.container}
       refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+      keyboardShouldPersistTaps="handled"
+      keyboardDismissMode="on-drag"
     >
       <View style={styles.content}>
         <Text style={styles.title}>{t("Challenge")}</Text>

--- a/src/components/Comments.tsx
+++ b/src/components/Comments.tsx
@@ -183,6 +183,7 @@ export const CommentsList: React.FC<CommentsListProps> = ({
             </View>
           )}
           keyboardShouldPersistTaps="handled"
+          keyboardDismissMode="on-drag"
         />
 
         <View style={inputContainerStyle}>

--- a/src/components/CreatePost.tsx
+++ b/src/components/CreatePost.tsx
@@ -93,10 +93,12 @@ const CreatePost = ({ onPostCreated }: CreatePostProps) => {
           keyboardVerticalOffset={Platform.OS === "ios" ? -64 : 0}
         >
           <View style={modalContainerStyle}>
-            <ScrollView
+              <ScrollView
               style={modalScrollStyle}
               contentContainerStyle={scrollContentStyle}
               showsVerticalScrollIndicator={false}
+              keyboardShouldPersistTaps="handled"
+              keyboardDismissMode="on-drag"
             >
               <View style={modalContentStyle}>
                 <View style={modalHeaderStyle}>

--- a/src/components/PostPage.tsx
+++ b/src/components/PostPage.tsx
@@ -68,6 +68,7 @@ const PostPage = () => {
         style={styles.scrollView}
         contentContainerStyle={styles.scrollViewContent}
         keyboardShouldPersistTaps="handled"
+        keyboardDismissMode="on-drag"
       >
         <Post
           post={post}

--- a/src/components/ProfilePage.tsx
+++ b/src/components/ProfilePage.tsx
@@ -256,6 +256,8 @@ export const ProfilePage: React.FC<ProfilePageProps> = ({ userId }) => {
           }
         }}
         scrollEventThrottle={400}
+        keyboardShouldPersistTaps="handled"
+        keyboardDismissMode="on-drag"
       >
         <View style={styles.profileHeader}>
           <View style={styles.headerLeft}>


### PR DESCRIPTION
* Fixes a bug where it was not possible to dismiss the keyboard (at least on iOS) -- does so by adding `keyboardDismissMode="on-drag"` to `ScrollsView`s and an onPress for components that have inputs that don't scroll.
* Also adds a max height to the challenge completion modal input since it was going off component when keyboard was up