### PR TITLE
fix: skip welcome post for existing users completing profile

### DIFF
--- a/src/app/(auth)/register-profile.tsx
+++ b/src/app/(auth)/register-profile.tsx
@@ -160,6 +160,7 @@ export default function RegisterProfileScreen() {
         profileMediaId,
         instagram: instagram,
         isSocialUser: isSocialSignUp,
+        isIncompleteProfile: isProfileCompletion,
       });
 
       if (isProfileCompletion) {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -16,6 +16,8 @@ type SignUpOptions = {
   instagram?: string;
   // Flag to indicate social (Google/Apple) signup
   isSocialUser?: boolean;
+  // Flag to indicate incomplete profile completion (existing user with null username)
+  isIncompleteProfile?: boolean;
 };
 
 type AuthContextType = {
@@ -215,7 +217,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   // Signup function for completing profile (user already authenticated)
   const signUp = async (options: SignUpOptions): Promise<string> => {
-    const { username, displayName, profileMediaId, instagram } = options;
+    const { username, displayName, profileMediaId, instagram, isIncompleteProfile } = options;
 
     // Get the already-authenticated user
     const { data: { session } } = await supabase.auth.getSession();
@@ -248,8 +250,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     setUsername(username);
 
-    // Create welcome post
-    await createWelcomePost(userId);
+    // Create welcome post (skip for existing users completing their profile)
+    if (!isIncompleteProfile) {
+      await createWelcomePost(userId);
+    }
 
     // Track sign up event
     captureEvent(AUTH_EVENTS.SIGNED_UP, {


### PR DESCRIPTION
Existing users with null usernames were getting a welcome post created when they completed the incomplete profile flow. This adds an isIncompleteProfile flag to signUp() so the welcome post is only created for genuinely new users.