### PR TITLE
fix(admin): paginate selected-user query for notifications

### DIFF
--- a/src/app/(tabs)/admin.tsx
+++ b/src/app/(tabs)/admin.tsx
@@ -153,13 +153,27 @@ const ChallengeCreation: React.FC = () => {
 
   const fetchUsers = async () => {
     try {
-      const { data, error } = await supabase
-        .from("profiles")
-        .select("id, username, name")
-        .order("username", { ascending: true });
+      const pageSize = 1000;
+      let from = 0;
+      const users: UserProfile[] = [];
 
-      if (error) throw error;
-      setAllUsers(data || []);
+      while (true) {
+        const { data, error } = await supabase
+          .from("profiles")
+          .select("id, username, name")
+          .order("username", { ascending: true })
+          .range(from, from + pageSize - 1);
+
+        if (error) throw error;
+
+        const page = (data || []) as UserProfile[];
+        users.push(...page);
+
+        if (page.length < pageSize) break;
+        from += pageSize;
+      }
+
+      setAllUsers(users);
     } catch (error) {
       console.error("Error fetching users:", error);
     }


### PR DESCRIPTION
## Summary\n- paginate admin user fetch in  using  batches of 1000\n- keep loading users until final partial page\n- fixes missing users in the "Send to selected users" picker when profile count exceeds Supabase default page cap\n\n## Why\nSupabase caps query results per request, so the admin user selector was only loading the first page of profiles.\n\n## Testing\n- manually verified code path loops over pages and aggregates all users\n- no behavior change for projects with <1000 users