### PR TITLE
feat(analytics): track push opt-in banner actions

### DIFF
--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -278,6 +278,10 @@ function RootLayoutNav() {
     if (!userId) return;
 
     const { status } = await Notifications.getPermissionsAsync();
+    captureEvent(UI_EVENTS.NOTIFICATIONS_BANNER_ENABLE_CLICKED, {
+      permission_status: status,
+    });
+
     if (status === 'granted') {
       await registerForPushNotificationsAsync(userId);
       setShowNotificationsBanner(false);
@@ -287,11 +291,19 @@ function RootLayoutNav() {
     await Linking.openSettings();
   };
 
-  const handleIgnoreNotificationsBanner = () => {
+  const handleIgnoreNotificationsBanner = async () => {
+    const { status } = await Notifications.getPermissionsAsync();
+    captureEvent(UI_EVENTS.NOTIFICATIONS_BANNER_NOT_NOW_CLICKED, {
+      permission_status: status,
+    });
     setShowNotificationsBanner(false);
   };
 
   const handleDisableNotificationsBanner = async () => {
+    const { status } = await Notifications.getPermissionsAsync();
+    captureEvent(UI_EVENTS.NOTIFICATIONS_BANNER_DONT_ASK_AGAIN_CLICKED, {
+      permission_status: status,
+    });
     await AsyncStorage.setItem(NOTIF_BANNER_DISABLED_KEY, '1');
     setShowNotificationsBanner(false);
   };

--- a/src/constants/analyticsEvents.ts
+++ b/src/constants/analyticsEvents.ts
@@ -88,6 +88,9 @@ export const UI_EVENTS = {
   MENU_OPENED: 'ui_menu_opened',
   FEEDBACK_MODAL_OPENED: 'ui_feedback_modal_opened',
   FEEDBACK_SUBMITTED: 'ui_feedback_submitted',
+  NOTIFICATIONS_BANNER_ENABLE_CLICKED: 'ui_notifications_banner_enable_clicked',
+  NOTIFICATIONS_BANNER_NOT_NOW_CLICKED: 'ui_notifications_banner_not_now_clicked',
+  NOTIFICATIONS_BANNER_DONT_ASK_AGAIN_CLICKED: 'ui_notifications_banner_dont_ask_again_clicked',
 } as const;
 
 // ============================================


### PR DESCRIPTION
## Summary
- add PostHog events for push-notification banner actions:
  - enable clicked
  - not now clicked
  - don't ask again clicked
- include current permission status in event payload (`permission_status`)
- add new UI event constants in analyticsEvents

## Why
We need visibility into how users interact with the push opt-in banner and where they drop off.

## Testing
- tap each banner action and verify event is emitted with permission_status
