### PR TITLE
add admin-only user search

### DIFF
--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -73,7 +73,8 @@ function RootLayoutNav() {
   const isDetailPage = pathname.includes('/post/') ||
     pathname.includes('/profile/') ||
     pathname.includes('/challenge/') ||
-    pathname === '/badges';
+    pathname === '/badges' ||
+    pathname === '/search-users';
 
   // hide logo on auth screens
   const hideLogo = pathname === '/login' || pathname === '/register' || pathname === '/forgot-password' || pathname === '/reset-password';

--- a/src/app/search-users.tsx
+++ b/src/app/search-users.tsx
@@ -1,0 +1,167 @@
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  TextInput,
+  FlatList,
+  TouchableOpacity,
+  Image,
+  ActivityIndicator,
+} from "react-native";
+import { router } from "expo-router";
+import { colors } from "../constants/Colors";
+import { profileService, UserSearchResult } from "../services/profileService";
+import { useLanguage } from "../contexts/LanguageContext";
+import { useAuth } from "../contexts/AuthContext";
+
+const SearchUsersScreen: React.FC = () => {
+  const { t } = useLanguage();
+  const { isAdmin } = useAuth();
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<UserSearchResult[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const normalizedQuery = useMemo(() => query.trim(), [query]);
+
+  useEffect(() => {
+    if (!isAdmin) {
+      router.replace("/");
+      return;
+    }
+
+    if (!normalizedQuery) {
+      setResults([]);
+      setLoading(false);
+      return;
+    }
+
+    const timeoutId = setTimeout(async () => {
+      try {
+        setLoading(true);
+        const users = await profileService.searchUsers(normalizedQuery);
+        setResults(users);
+      } catch (error) {
+        console.error("Error searching users:", error);
+      } finally {
+        setLoading(false);
+      }
+    }, 300);
+
+    return () => clearTimeout(timeoutId);
+  }, [isAdmin, normalizedQuery]);
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>{t("Search users")}</Text>
+
+      <TextInput
+        value={query}
+        onChangeText={setQuery}
+        placeholder={t("Search by name or username")}
+        placeholderTextColor={colors.light.lightText}
+        style={styles.input}
+        autoCapitalize="none"
+      />
+
+      {loading && (
+        <View style={styles.loadingRow}>
+          <ActivityIndicator color={colors.light.primary} />
+        </View>
+      )}
+
+      {!loading && normalizedQuery.length === 0 && (
+        <Text style={styles.helperText}>{t("Start typing to find people")}</Text>
+      )}
+
+      {!loading && normalizedQuery.length > 0 && results.length === 0 && (
+        <Text style={styles.helperText}>{t("No users found")}</Text>
+      )}
+
+      <FlatList
+        data={results}
+        keyExtractor={(item) => item.id}
+        keyboardShouldPersistTaps="handled"
+        renderItem={({ item }) => (
+          <TouchableOpacity
+            style={styles.userRow}
+            onPress={() => router.push(`/profile/${item.id}`)}
+          >
+            <Image
+              source={
+                item.profileImageUrl
+                  ? { uri: item.profileImageUrl }
+                  : require("../assets/images/default-pfp.png")
+              }
+              style={styles.avatar}
+            />
+            <View style={styles.userTextContainer}>
+              <Text style={styles.name}>{item.name}</Text>
+              <Text style={styles.username}>@{item.username}</Text>
+            </View>
+          </TouchableOpacity>
+        )}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.light.background,
+    padding: 16,
+  },
+  title: {
+    fontSize: 22,
+    fontWeight: "700",
+    color: colors.light.primary,
+    marginBottom: 12,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: colors.neutral.grey1,
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    color: colors.light.primary,
+    marginBottom: 12,
+  },
+  loadingRow: {
+    alignItems: "center",
+    paddingVertical: 12,
+  },
+  helperText: {
+    color: colors.light.lightText,
+    textAlign: "center",
+    marginTop: 12,
+  },
+  userRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 10,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.neutral.grey1 + "66",
+  },
+  avatar: {
+    width: 42,
+    height: 42,
+    borderRadius: 21,
+    marginRight: 12,
+    backgroundColor: colors.neutral.grey1,
+  },
+  userTextContainer: {
+    flex: 1,
+  },
+  name: {
+    color: colors.light.primary,
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  username: {
+    color: colors.light.lightText,
+    marginTop: 2,
+  },
+});
+
+export default SearchUsersScreen;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,6 +5,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { colors } from '../constants/Colors'; 
 import { router } from 'expo-router';
 import { useUploadProgress } from '../contexts/UploadProgressContext';
+import { useAuth } from '../contexts/AuthContext';
 
 interface HeaderProps {
   onNotificationPress: () => void;
@@ -24,6 +25,7 @@ const Header = ({
   hideLogo = false
 }: HeaderProps) => {
   const { uploadProgress, uploadMessage } = useUploadProgress();
+  const { isAdmin } = useAuth();
   const progressAnimation = useRef(new Animated.Value(0)).current;
   const messageOpacity = useRef(new Animated.Value(0)).current;
 
@@ -122,6 +124,14 @@ const Header = ({
         )}
         
         <View style={styles.headerRight}>
+          {isAdmin && (
+            <TouchableOpacity
+              style={styles.searchIcon}
+              onPress={() => router.push('/search-users')}
+            >
+              <Ionicons name="search" size={24} color={colors.light.primary} />
+            </TouchableOpacity>
+          )}
           <TouchableOpacity 
             style={styles.feedbackIcon}
             onPress={onFeedbackPress}
@@ -162,6 +172,10 @@ const styles = StyleSheet.create({
     color: '#fff',
     fontSize: 12,
     fontWeight: 'bold',
+  },
+  searchIcon: {
+    marginRight: 14,
+    position: 'relative',
   },
   feedbackIcon: {
     marginRight: 16,

--- a/src/constants/translations.ts
+++ b/src/constants/translations.ts
@@ -307,4 +307,8 @@ export const translations = {
   "Unlocked": "Sbloccati",
   "Obtained": "Ottenuto",
   "All badges": "Tutti i badge",
+  "Search users": "Cerca utenti",
+  "Search by name or username": "Cerca per nome o nome utente",
+  "Start typing to find people": "Inizia a digitare per trovare persone",
+  "No users found": "Nessun utente trovato",
 };

--- a/src/services/profileService.ts
+++ b/src/services/profileService.ts
@@ -4,6 +4,13 @@ import { Alert } from "react-native";
 import { User, UserProfile } from "../models/User";
 import { imageService } from "./imageService";
 
+export interface UserSearchResult {
+  id: string;
+  username: string;
+  name: string;
+  profileImageUrl: string | null;
+}
+
 export const profileService = {
   async updateProfilePicture(
     userId: string,
@@ -265,8 +272,8 @@ export const profileService = {
       let profileImageUrl = null;
 
       // Handle profile_media - it can be an object or array from Supabase
-      const profileMedia = Array.isArray(data.profile_media) 
-        ? data.profile_media[0] 
+      const profileMedia = Array.isArray(data.profile_media)
+        ? data.profile_media[0]
         : data.profile_media;
 
       if (profileMedia?.file_path) {
@@ -291,5 +298,81 @@ export const profileService = {
       console.error("Error fetching profile:", error);
       throw error; // Re-throw for React Query to handle
     }
+  },
+
+  async searchUsers(query: string, limit: number = 20): Promise<UserSearchResult[]> {
+    const normalizedQuery = query.trim();
+    if (!normalizedQuery) {
+      return [];
+    }
+
+    const searchColumns = `
+      id,
+      username,
+      name,
+      profile_media:media!profiles_profile_media_id_fkey (
+        file_path
+      )
+    `;
+
+    const [usernameRes, nameRes] = await Promise.all([
+      supabase
+        .from("profiles")
+        .select(searchColumns)
+        .ilike("username", `%${normalizedQuery}%`)
+        .limit(limit),
+      supabase
+        .from("profiles")
+        .select(searchColumns)
+        .ilike("name", `%${normalizedQuery}%`)
+        .limit(limit),
+    ]);
+
+    if (usernameRes.error) throw usernameRes.error;
+    if (nameRes.error) throw nameRes.error;
+
+    const merged = new Map<string, {
+      id: string;
+      username: string | null;
+      name: string | null;
+      profile_media?: { file_path?: string | null } | Array<{ file_path?: string | null }> | null;
+    }>();
+
+    [...(usernameRes.data || []), ...(nameRes.data || [])].forEach((row) => {
+      if (!merged.has(row.id)) {
+        merged.set(row.id, row);
+      }
+    });
+
+    const users = await Promise.all(
+      Array.from(merged.values()).slice(0, limit).map(async (row) => {
+        const profileMedia = Array.isArray(row.profile_media)
+          ? row.profile_media[0]
+          : row.profile_media;
+
+        let profileImageUrl: string | null = null;
+        if (profileMedia?.file_path) {
+          try {
+            const urls = await imageService.getProfileImageUrl(profileMedia.file_path, "small");
+            profileImageUrl = urls.fullUrl;
+          } catch (error) {
+            console.error("Error transforming profile image:", error);
+          }
+        }
+
+        return {
+          id: row.id,
+          username: row.username || "Unknown",
+          name: row.name || "Unknown",
+          profileImageUrl,
+        };
+      })
+    );
+
+    return users.sort((a, b) => {
+      const aStarts = a.username.toLowerCase().startsWith(normalizedQuery.toLowerCase()) ? 1 : 0;
+      const bStarts = b.username.toLowerCase().startsWith(normalizedQuery.toLowerCase()) ? 1 : 0;
+      return bStarts - aStarts;
+    });
   },
 };


### PR DESCRIPTION
## Summary
- add a new  screen to search profiles by name or username
- show profile image, name, and username in results
- wire search entry point in header and restrict it to admins only
- guard  route so non-admin users are redirected home

## Notes
- fixed avatar mapping in search results to use 
- added i18n keys for search UI strings