### PR TITLE
fix: make Notify All inserts pass notifications RLS

### DIFF
--- a/src/lib/notificationsService.ts
+++ b/src/lib/notificationsService.ts
@@ -159,13 +159,14 @@ export async function sendCommentNotification(
 }
 
 // Handle sending notifications for new challenges
-export async function sendNewChallengeNotification(recipientId: string, challengeId: string, challengeTitle: string) {
-    // Save notification to database so it persists (and shows in the in-app badge)
+export async function sendNewChallengeNotification(recipientId: string, challengeId: string, challengeTitle: string, triggerUserId: string) {
+    // Save notification to database so it persists (and shows in the in-app badge).
+    // trigger_user_id must equal auth.uid() to satisfy the notifications RLS insert policy.
     const { error: dbError } = await supabase
         .from('notifications')
         .insert([{
             user_id: recipientId,
-            trigger_user_id: null,
+            trigger_user_id: triggerUserId,
             action_type: 'new_challenge',
             is_read: false,
             challenge_id: challengeId,
@@ -173,7 +174,7 @@ export async function sendNewChallengeNotification(recipientId: string, challeng
 
     if (dbError) {
         console.error('Error saving new challenge notification to database:', dbError);
-        // still try to send push
+        throw dbError;
     }
 
     const pushToken = await getPushToken(recipientId);
@@ -214,11 +215,16 @@ async function getAllUserIds(): Promise<string[]> {
 
 // Handle sending notifications to all users about a new challenge
 export async function sendNewChallengeNotificationToAll(challengeId: string, challengeTitle: string) {
+    const { data: { user }, error: userError } = await supabase.auth.getUser();
+    if (userError || !user) {
+        throw userError ?? new Error('Not authenticated');
+    }
+
     const userIds = await getAllUserIds();
 
     // Send notification to each user
     const notifications = userIds.map(userId =>
-        sendNewChallengeNotification(userId, challengeId, challengeTitle)
+        sendNewChallengeNotification(userId, challengeId, challengeTitle, user.id)
     );
 
     await Promise.all(notifications);


### PR DESCRIPTION
Pass the admin's auth.uid() as trigger_user_id on new_challenge inserts so the RLS policy (auth.uid() = trigger_user_id) accepts the rows. Inserts were silently rejected, so recipients never saw a sidebar entry or app-icon badge bump. Also surface the insert error instead of swallowing it.