### PR TITLE
fix(recently-active): count active users regardless of profile photo

### DIFF
--- a/src/hooks/useRecentlyActiveUsers.ts
+++ b/src/hooks/useRecentlyActiveUsers.ts
@@ -33,8 +33,7 @@ async function fetchRecentlyActiveCount(): Promise<number> {
   const { count, error } = await supabase
     .from('profiles')
     .select('*', { count: 'exact', head: true })
-    .eq('is_recently_active', true)
-    .not('profile_media_id', 'is', null);
+    .eq('is_recently_active', true);
 
   if (error) throw error;
   return count || 0;


### PR DESCRIPTION
## Summary
- update recently-active count query to include all users with 
- keep avatar list behavior unchanged (still only displays users with profile photos)

## Why
The top banner count should reflect true active users, even if some have no profile image. But the avatar row should continue showing only users with photos.