### PR TITLE
fix(notify-all): attribute new-challenge notifications to Stepn Out account

### DIFF
--- a/src/lib/notificationsService.ts
+++ b/src/lib/notificationsService.ts
@@ -161,7 +161,6 @@ export async function sendCommentNotification(
 // Handle sending notifications for new challenges
 export async function sendNewChallengeNotification(recipientId: string, challengeId: string, challengeTitle: string, triggerUserId: string) {
     // Save notification to database so it persists (and shows in the in-app badge).
-    // trigger_user_id must equal auth.uid() to satisfy the notifications RLS insert policy.
     const { error: dbError } = await supabase
         .from('notifications')
         .insert([{
@@ -213,18 +212,16 @@ async function getAllUserIds(): Promise<string[]> {
     return allIds;
 }
 
+// Trigger user for system-sent notifications (e.g. weekly "new challenge"),
+// so the in-app sidebar attributes them to "Stepn Out" instead of the admin.
+const STEPNOUT_USER_ID = 'a7ce5ebb-00fc-40d7-b8be-1dfd906a13c7';
+
 // Handle sending notifications to all users about a new challenge
 export async function sendNewChallengeNotificationToAll(challengeId: string, challengeTitle: string) {
-    const { data: { user }, error: userError } = await supabase.auth.getUser();
-    if (userError || !user) {
-        throw userError ?? new Error('Not authenticated');
-    }
-
     const userIds = await getAllUserIds();
 
-    // Send notification to each user
     const notifications = userIds.map(userId =>
-        sendNewChallengeNotification(userId, challengeId, challengeTitle, user.id)
+        sendNewChallengeNotification(userId, challengeId, challengeTitle, STEPNOUT_USER_ID)
     );
 
     await Promise.all(notifications);

--- a/supabase/migrations/20260507000000_allow_admin_notification_trigger_user.sql
+++ b/supabase/migrations/20260507000000_allow_admin_notification_trigger_user.sql
@@ -1,0 +1,8 @@
+-- Allow admins to insert notifications with any trigger_user_id (e.g. the
+-- "Stepn Out" system profile for Notify All), not just their own auth.uid().
+DROP POLICY IF EXISTS "notifications_insert_authenticated" ON public.notifications;
+
+CREATE POLICY "notifications_insert_authenticated"
+  ON public.notifications FOR INSERT
+  TO authenticated
+  WITH CHECK (auth.uid() = trigger_user_id OR public.is_admin());


### PR DESCRIPTION
Hardcodes the Stepn Out profile as trigger_user_id so the in-app sidebar shows the system account instead of the admin who clicked Notify All. Relaxes the notifications insert RLS policy to allow admins to set any trigger_user_id.