### PR TITLE
fix(home): paint red heart in sync with rest of feed

### DIFF
--- a/src/contexts/LikesContext.tsx
+++ b/src/contexts/LikesContext.tsx
@@ -17,7 +17,10 @@ interface LikesContextType {
     userId: string,
     commentUserId: string
   ) => Promise<void>;
-  initializePostLikes: (posts: Post[]) => Promise<void>;
+  initializePostLikes: (
+    posts: Post[],
+    seedLikedMap?: { [postId: number]: boolean }
+  ) => Promise<void>;
   initializeCommentLikes: (comments: Comment[]) => Promise<void>;
 }
 
@@ -31,7 +34,11 @@ export const LikesProvider: React.FC<{ children: React.ReactNode }> = ({ childre
   const [pendingLikes, setPendingLikes] = useState<{ [id: number]: boolean }>({});
   const { user } = useAuth();
 
-  const initializeLikes = async (items: (Post | Comment)[], type: "post" | "comment") => {
+  const initializeLikes = async (
+    items: (Post | Comment)[],
+    type: "post" | "comment",
+    seedLikedMap?: { [id: number]: boolean }
+  ) => {
     const ids = items.map((item) => item.id);
 
     const setLikedItems = type === "post" ? setLikedPosts : setLikedComments;
@@ -47,13 +54,20 @@ export const LikesProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       ),
     }));
 
-    // seed liked state from items that already carry a `liked` field to avoid grey→red flash
+    // seed liked state synchronously. Prefer the pre-fetched seed map when provided.
     setLikedItems((prev) => ({
       ...prev,
       ...Object.fromEntries(
-        items.map((item) => [item.id, item.liked ?? false])
+        items.map((item) => [
+          item.id,
+          seedLikedMap ? !!seedLikedMap[item.id] : (item.liked ?? false),
+        ])
       ),
     }));
+
+    // Caller already has authoritative liked data — skip the redundant network round-trip
+    // that would otherwise cause hearts to lag behind the rest of the feed.
+    if (seedLikedMap) return;
 
     const [likesMap, countsMap] = await Promise.all([
       type === "post"
@@ -156,7 +170,8 @@ export const LikesProvider: React.FC<{ children: React.ReactNode }> = ({ childre
           toggleLike({ id: postId, type: "post" }, userId, postUserId),
         toggleCommentLike: (commentId, postId, userId, commentUserId) =>
           toggleLike({ id: commentId, type: "comment", parentId: postId }, userId, commentUserId),
-        initializePostLikes: (posts) => initializeLikes(posts, "post"),
+        initializePostLikes: (posts, seedLikedMap) =>
+          initializeLikes(posts, "post", seedLikedMap),
         initializeCommentLikes: (comments) => initializeLikes(comments, "comment"),
       }}
     >

--- a/src/hooks/useFetchHomeData.ts
+++ b/src/hooks/useFetchHomeData.ts
@@ -335,13 +335,14 @@ export const useFetchHomeData = (
     });
   }, [allPosts.length, userMap, updateDiagnostics]);
 
-  // Initialize likes when posts change
+  // Initialize likes when posts change, and re-seed when the user's liked-post
+  // pre-fetch resolves so the red heart paints in sync with everything else.
   useEffect(() => {
     if (allPosts.length > 0) {
-      initializePostLikes(allPosts);
+      initializePostLikes(allPosts, userLikedPostIds);
       initializePostReactions(allPosts);
     }
-  }, [allPosts.length]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [allPosts.length, userLikedPostIds]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const loadMoreChallenges = useCallback(() => {
     if (!challengeLoading && !isFetchingNextChallengePage && hasMoreChallenges) {


### PR DESCRIPTION
## Summary
- On the home feed, the like count painted instantly but the red heart consistently lagged a beat behind.
- Root cause: `LikesContext.initializeLikes` was kicking off a `fetchPostsLikes` round-trip on every init, even though `useFetchHomeData` already pre-fetches the user's liked post IDs via the `user-liked-posts` query. The count seeded synchronously from `post.likes_count`; the heart had to wait for that extra network request.
- Additionally, the init effect only depended on `allPosts.length`, so if `userLikedPostIds` resolved *after* posts, hearts wouldn't re-seed from the pre-fetched map.

## Fix
- `initializePostLikes` now accepts an optional `seedLikedMap`. When provided, it seeds liked state synchronously from that map and skips the redundant `fetchPostsLikes` call.
- `useFetchHomeData` passes `userLikedPostIds` as the seed map and includes it in the effect's deps so the heart re-seeds the moment the pre-fetch resolves.

## Test plan
- [ ] Cold-load the home feed; red heart appears in the same frame as the count for posts the user has liked.
- [ ] Pull-to-refresh on home; no flash of grey → red.
- [ ] Toggle like on a post; optimistic update still works.
- [ ] Scroll to load next page; new posts initialize liked state correctly.
- [ ] Open a post detail screen / profile / challenge feed (callers that don't pass a seed map); existing behavior preserved (still uses `fetchPostsLikes`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)