### PR TITLE
Improve on complete animation

### DIFF
--- a/src/app/(auth)/forgot-password.tsx
+++ b/src/app/(auth)/forgot-password.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { TextInput, StyleSheet, TouchableOpacity, Alert, KeyboardAvoidingView, Platform, Pressable, Keyboard } from 'react-native';
+import { TextInput, StyleSheet, TouchableOpacity, KeyboardAvoidingView, Platform, Pressable, Keyboard } from 'react-native';
+import { AppAlert } from '../../components/AppAlert';
 import { router } from 'expo-router';
 import * as Linking from 'expo-linking';
 import { colors } from '../../constants/Colors';
@@ -14,7 +15,7 @@ export default function ForgotPasswordScreen() {
 
   const handleSendReset = async () => {
     if (!email) {
-      Alert.alert(t('Error'), t('Please enter your email'));
+      AppAlert.show(t('Error'), t('Please enter your email'));
       return;
     }
 
@@ -28,14 +29,14 @@ export default function ForgotPasswordScreen() {
 
       if (error) throw error;
 
-      Alert.alert(t('Success'), t('Password reset email sent'), [
+      AppAlert.show(t('Success'), t('Password reset email sent'), [
         {
           text: t('OK'),
           onPress: () => router.replace('/(auth)/login'),
         },
       ]);
     } catch (error) {
-      Alert.alert(t('Error'), (error as Error).message);
+      AppAlert.show(t('Error'), (error as Error).message);
     } finally {
       setLoading(false);
     }

--- a/src/app/(auth)/login.tsx
+++ b/src/app/(auth)/login.tsx
@@ -6,11 +6,11 @@ import {
   TouchableOpacity,
   KeyboardAvoidingView,
   Platform,
-  Alert,
   Image,
   Keyboard,
   Pressable,
 } from 'react-native';
+import { AppAlert } from '../../components/AppAlert';
 import { router } from 'expo-router';
 import { colors } from '../../constants/Colors';
 import { useAuth } from '../../contexts/AuthContext';
@@ -92,7 +92,7 @@ export default function LoginScreen() {
 
   const handleGoogleSignIn = async (idToken: string | undefined) => {
     if (!idToken) {
-      Alert.alert(t('Error'), t('Failed to get Google credentials'));
+      AppAlert.show(t('Error'), t('Failed to get Google credentials'));
       return;
     }
 
@@ -100,7 +100,7 @@ export default function LoginScreen() {
       setGoogleLoading(true);
       await handleSocialSignIn('google', idToken);
     } catch (error) {
-      Alert.alert(t('Error'), (error as Error).message);
+      AppAlert.show(t('Error'), (error as Error).message);
     } finally {
       setGoogleLoading(false);
     }
@@ -127,7 +127,7 @@ export default function LoginScreen() {
       if ((error as { code?: string })?.code === 'ERR_REQUEST_CANCELED') {
         return;
       }
-      Alert.alert(t('Error'), (error as Error).message);
+      AppAlert.show(t('Error'), (error as Error).message);
     } finally {
       setAppleLoading(false);
     }
@@ -135,7 +135,7 @@ export default function LoginScreen() {
 
   const handleLogin = async () => {
     if (!email || !password) {
-      Alert.alert(t('Error'), t('Please fill in all fields'));
+      AppAlert.show(t('Error'), t('Please fill in all fields'));
       return;
     }
     try {
@@ -176,7 +176,7 @@ export default function LoginScreen() {
         router.replace('/(tabs)');
       }
     } catch (error) {
-      Alert.alert(t('Error'), (error as Error).message);
+      AppAlert.show(t('Error'), (error as Error).message);
     } finally {
       setLoading(false);
     }

--- a/src/app/(auth)/register-profile.tsx
+++ b/src/app/(auth)/register-profile.tsx
@@ -7,10 +7,10 @@ import {
   KeyboardAvoidingView,
   Platform,
   Image,
-  Alert,
   Keyboard,
   Pressable,
 } from "react-native";
+import { AppAlert } from '../../components/AppAlert';
 import { router, useLocalSearchParams } from "expo-router";
 import { colors } from "../../constants/Colors";
 import { useAuth } from "../../contexts/AuthContext";
@@ -112,7 +112,7 @@ export default function RegisterProfileScreen() {
         setProfileImage(file.uri);
       } catch (error) {
         console.error("Error uploading profile image:", error);
-        Alert.alert(t("Error"), t("Failed to upload profile image"));
+        AppAlert.show(t("Error"), t("Failed to upload profile image"));
       } finally {
         setImageUploading(false);
       }

--- a/src/app/(auth)/reset-password.tsx
+++ b/src/app/(auth)/reset-password.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { TextInput, StyleSheet, TouchableOpacity, Alert, KeyboardAvoidingView, Platform, Pressable, Keyboard } from 'react-native';
+import { TextInput, StyleSheet, TouchableOpacity, KeyboardAvoidingView, Platform, Pressable, Keyboard } from 'react-native';
+import { AppAlert } from '../../components/AppAlert';
 import { router } from 'expo-router';
 import { colors } from '../../constants/Colors';
 import { Text } from '../../components/StyledText';
@@ -14,12 +15,12 @@ export default function ResetPasswordScreen() {
 
   const handleUpdatePassword = async () => {
     if (!password || !confirmPassword) {
-      Alert.alert(t('Error'), t('Please fill in all fields'));
+      AppAlert.show(t('Error'), t('Please fill in all fields'));
       return;
     }
 
     if (password !== confirmPassword) {
-      Alert.alert(t('Error'), t('Passwords do not match'));
+      AppAlert.show(t('Error'), t('Passwords do not match'));
       return;
     }
 
@@ -50,14 +51,14 @@ export default function ResetPasswordScreen() {
 
       clearRecoveryTokens();
 
-      Alert.alert(t('Success'), t('Password updated'), [
+      AppAlert.show(t('Success'), t('Password updated'), [
         {
           text: t('OK'),
           onPress: () => router.replace('/(auth)/login'),
         },
       ]);
     } catch (error) {
-      Alert.alert(t('Error'), (error as Error).message);
+      AppAlert.show(t('Error'), (error as Error).message);
     } finally {
       setLoading(false);
     }

--- a/src/app/(tabs)/admin.tsx
+++ b/src/app/(tabs)/admin.tsx
@@ -4,12 +4,12 @@ import {
   Text,
   TextInput,
   StyleSheet,
-  Alert,
   TouchableOpacity,
   Image,
   ScrollView,
   RefreshControl,
 } from "react-native";
+import { AppAlert } from '../../components/AppAlert';
 import DropDownPicker from "react-native-dropdown-picker";
 import { supabase } from "../../lib/supabase";
 import { colors } from "../../constants/Colors";
@@ -151,7 +151,7 @@ const ChallengeCreation: React.FC = () => {
       setChallenges(data || []);
     } catch (error) {
       console.error("Error fetching challenges:", error);
-      Alert.alert("Error", "Failed to load challenges");
+      AppAlert.show("Error", "Failed to load challenges");
     }
   };
 
@@ -378,7 +378,7 @@ const ChallengeCreation: React.FC = () => {
       }
     } catch (error) {
       console.error("Error uploading file:", error);
-      Alert.alert("Error", "Failed to upload image");
+      AppAlert.show("Error", "Failed to upload image");
     }
   };
 
@@ -400,9 +400,9 @@ const ChallengeCreation: React.FC = () => {
 
       if (error) {
         console.error("Error inserting data:", error);
-        Alert.alert("Error", error.message);
+        AppAlert.show("Error", error.message);
       } else {
-        Alert.alert("Success", "Challenge created successfully!");
+        AppAlert.show("Success", "Challenge created successfully!");
         setTitle("");
         setDescription("");
         setDifficulty("easy");
@@ -412,13 +412,13 @@ const ChallengeCreation: React.FC = () => {
       }
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : "An unknown error occurred";
-      Alert.alert("Error", errorMessage);
+      AppAlert.show("Error", errorMessage);
     }
   };
 
   const handleCreateChallenge = () => {
     if (!title || !description || !difficulty) {
-      Alert.alert("Error", "All fields must be filled out.");
+      AppAlert.show("Error", "All fields must be filled out.");
       return;
     }
     createChallengeInDatabase();
@@ -450,20 +450,20 @@ const ChallengeCreation: React.FC = () => {
 
       // Refresh the challenges list
       await fetchChallenges();
-      Alert.alert("Success", "Challenge activated!");
+      AppAlert.show("Success", "Challenge activated!");
     } catch (error) {
       console.error("Error activating challenge:", error);
-      Alert.alert("Error", "Failed to activate challenge");
+      AppAlert.show("Error", "Failed to activate challenge");
     }
   };
 
   const handleSendNotifications = async (challengeId: number, challengeTitle: string) => {
     try {
       await sendNewChallengeNotificationToAll(challengeId.toString(), challengeTitle);
-      Alert.alert("Success", "Notifications sent to all users!");
+      AppAlert.show("Success", "Notifications sent to all users!");
     } catch (error) {
       console.error("Error sending notifications:", error);
-      Alert.alert("Error", "Failed to send notifications");
+      AppAlert.show("Error", "Failed to send notifications");
     }
   };
 
@@ -476,7 +476,7 @@ const ChallengeCreation: React.FC = () => {
   const handleGenerateTwoDayNotification = async () => {
     const activeChallenge = challenges.find((c) => c.is_active);
     if (!activeChallenge) {
-      Alert.alert("Error", "No active challenge found");
+      AppAlert.show("Error", "No active challenge found");
       return;
     }
 
@@ -498,7 +498,7 @@ const ChallengeCreation: React.FC = () => {
       setTwoDayNotifEnglishPreview(data?.englishBody || "");
     } catch (error) {
       console.error("Error generating 2-day notification:", error);
-      Alert.alert("Error", "Failed to generate notification");
+      AppAlert.show("Error", "Failed to generate notification");
     } finally {
       setGeneratingTwoDayNotif(false);
     }
@@ -506,7 +506,7 @@ const ChallengeCreation: React.FC = () => {
 
   const handleSendCustomNotification = async () => {
     if (!notifTitle.trim() || !notifBody.trim()) {
-      Alert.alert("Error", "Title and body are required");
+      AppAlert.show("Error", "Title and body are required");
       return;
     }
 
@@ -515,14 +515,14 @@ const ChallengeCreation: React.FC = () => {
       : selectedUserIds;
 
     if (targetUserIds.length === 0) {
-      Alert.alert("Error", "No users selected");
+      AppAlert.show("Error", "No users selected");
       return;
     }
 
     setSendingNotification(true);
     try {
       const result = await sendCustomNotification(notifTitle.trim(), notifBody.trim(), targetUserIds);
-      Alert.alert(
+      AppAlert.show(
         "Done",
         `Sent: ${result.sent}\nFailed: ${result.failed}\nNo push token: ${result.noToken}`
       );
@@ -532,7 +532,7 @@ const ChallengeCreation: React.FC = () => {
       setSelectedUserIds([]);
     } catch (error) {
       console.error("Error sending custom notification:", error);
-      Alert.alert("Error", "Failed to send notifications");
+      AppAlert.show("Error", "Failed to send notifications");
     } finally {
       setSendingNotification(false);
     }

--- a/src/app/(tabs)/index.tsx
+++ b/src/app/(tabs)/index.tsx
@@ -9,7 +9,6 @@ import {
   Text,
   StyleSheet,
 } from "react-native";
-import { useQueryClient } from "@tanstack/react-query";
 import Post from "../../components/Post";
 import WelcomePostGroup from "../../components/WelcomePostGroup";
 import FeedSortToggle from "../../components/FeedSortToggle";
@@ -64,7 +63,6 @@ const prepareFeedItems = (posts: PostType[]): FeedItem[] => {
 const Home = () => {
   const { t } = useLanguage();
   const router = useRouter();
-  const queryClient = useQueryClient();
   const { firstTime } = useLocalSearchParams<{ firstTime?: string }>();
   const defaultSort: FeedSort = firstTime === "true" ? "popular" : "recent";
   const [, setPostCounts] = useState<Record<number, { likes: number; comments: number }>>({});
@@ -107,30 +105,6 @@ const Home = () => {
     }
   }, [refetchPosts]);
 
-  const handlePostDeleted = useCallback((post: PostType) => {
-    type HomePostsPage = { posts: PostType[]; hasMore: boolean };
-    type HomePostsData = { pages: HomePostsPage[]; pageParams: number[] };
-
-    queryClient.setQueriesData<HomePostsData>({ queryKey: ["home-posts"] }, (oldData) => {
-      if (!oldData) return oldData;
-      return {
-        ...oldData,
-        pages: oldData.pages.map((page) => ({
-          ...page,
-          posts: page.posts.filter((pagePost) => pagePost.id !== post.id),
-        })),
-      };
-    });
-
-    if (post.challenge_id) {
-      queryClient.invalidateQueries({ queryKey: ["challenge-completion", post.challenge_id] });
-    }
-
-    if (post.quest_id) {
-      queryClient.invalidateQueries({ queryKey: ["quest-completion", post.quest_id] });
-    }
-  }, [queryClient]);
-
   const handlePostCreated = useCallback(() => {
     refetchPosts();
   }, [refetchPosts]);
@@ -170,11 +144,10 @@ const Home = () => {
           post={item.post}
           postUser={postUser}
           setPostCounts={setPostCounts}
-          onPostDeleted={handlePostDeleted}
         />
       );
     },
-    [expandedWelcomeGroups, handlePostDeleted, toggleWelcomeGroup, userMap]
+    [expandedWelcomeGroups, toggleWelcomeGroup, userMap]
   );
 
   const renderEmpty = useCallback(() => {

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -17,6 +17,7 @@ import * as SplashScreen from 'expo-splash-screen';
 import NotificationSidebar from '../components/NotificationSidebar';
 import MenuSidebar from '../components/MenuSidebar';
 import FeedbackModal from '../components/FeedbackModal';
+import { AppAlertHost } from '../components/AppAlert';
 import { useNotifications } from '../hooks/useNotifications';
 import { usePathname } from 'expo-router';
 import { LikesProvider } from '../contexts/LikesContext';
@@ -473,6 +474,7 @@ function RootLayoutNav() {
         isVisible={showFeedback}
         onClose={() => setShowFeedback(false)}
       />
+      <AppAlertHost />
     </SafeAreaView>
   );
 }

--- a/src/components/ActionsMenu.tsx
+++ b/src/components/ActionsMenu.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { Alert, ViewStyle, TextStyle, View } from "react-native";
+import { ViewStyle, TextStyle, View } from "react-native";
+import { AppAlert } from './AppAlert';
 import { Menu, MenuTrigger, MenuOptions, MenuOption } from "react-native-popup-menu";
 import { Text } from "./StyledText";
 import { colors } from "../constants/Colors";
@@ -45,7 +46,7 @@ export const ActionsMenu: React.FC<MenuProps> = ({
   const { user } = useAuth();
 
   const handleDelete = () => {
-    Alert.alert(t(`Delete ${type}`), t(`Are you sure you want to delete this ${type}?`), [
+    AppAlert.show(t(`Delete ${type}`), t(`Are you sure you want to delete this ${type}?`), [
       {
         text: t("Cancel"),
         style: "cancel",
@@ -70,7 +71,7 @@ export const ActionsMenu: React.FC<MenuProps> = ({
   const handleReport = () => {
     if (!user?.id) return;
 
-    Alert.alert(t(`Report ${type}`), t(`Are you sure you want to report this ${type}?`), [
+    AppAlert.show(t(`Report ${type}`), t(`Are you sure you want to report this ${type}?`), [
       {
         text: t("Cancel"),
         style: "cancel",
@@ -85,7 +86,7 @@ export const ActionsMenu: React.FC<MenuProps> = ({
               : await postService.reportComment(contentId, user.id, contentUserId);
 
           if (success) {
-            Alert.alert(t("Report Submitted"), t("Thank you for your report."));
+            AppAlert.show(t("Report Submitted"), t("Thank you for your report."));
           }
         },
       },
@@ -95,7 +96,7 @@ export const ActionsMenu: React.FC<MenuProps> = ({
   const handleBlock = () => {
     if (!user?.id) return;
 
-    Alert.alert(t("Block user"), t("Are you sure you want to block this user?"), [
+    AppAlert.show(t("Block user"), t("Are you sure you want to block this user?"), [
       {
         text: t("Cancel"),
         style: "cancel",

--- a/src/components/ActionsMenu.tsx
+++ b/src/components/ActionsMenu.tsx
@@ -1,13 +1,15 @@
 import React from "react";
 import { ViewStyle, TextStyle, View } from "react-native";
 import { AppAlert } from './AppAlert';
-import { Menu, MenuTrigger, MenuOptions, MenuOption } from "react-native-popup-menu";
+import { Menu, MenuTrigger, MenuOptions, MenuOption, renderers } from "react-native-popup-menu";
 import { Text } from "./StyledText";
 import { colors } from "../constants/Colors";
 import { useLanguage } from "../contexts/LanguageContext";
 import { useAuth } from "../contexts/AuthContext";
 import { postService } from "../services/postService";
 import { MaterialIcons } from "@expo/vector-icons";
+
+const { Popover } = renderers;
 
 type ContentType = "post" | "comment";
 
@@ -24,7 +26,6 @@ interface MenuProps {
   contentId: number;
   contentUserId: string;
   onDelete?: (id: number) => void;
-  menuOffset?: number;
 }
 
 interface ProfileActionsProps {
@@ -40,7 +41,6 @@ export const ActionsMenu: React.FC<MenuProps> = ({
   contentId,
   contentUserId,
   onDelete,
-  menuOffset = 20,
 }) => {
   const { t } = useLanguage();
   const { user } = useAuth();
@@ -140,17 +140,13 @@ export const ActionsMenu: React.FC<MenuProps> = ({
   };
 
   return (
-    <Menu style={menuContainer}>
+    <Menu
+      style={menuContainer}
+      renderer={Popover}
+      rendererProps={{ placement: 'top' }}
+    >
       <MenuTrigger>{children}</MenuTrigger>
-      <MenuOptions
-        customStyles={{
-          ...optionsStyles,
-          optionsContainer: {
-            ...optionsStyles.optionsContainer,
-            marginTop: menuOffset,
-          },
-        }}
-      >
+      <MenuOptions customStyles={optionsStyles}>
         {getActions().map((action, index) => (
           <React.Fragment key={index}>
             <MenuOption onSelect={action.onSelect}>
@@ -247,7 +243,9 @@ const optionsStyles = {
   optionsContainer: {
     borderRadius: 8,
     width: 200,
-    backgroundColor: colors.neutral.grey2,
+    backgroundColor: colors.neutral.white,
+    borderWidth: 1,
+    borderColor: colors.neutral.grey2,
     shadowColor: "transparent",
     shadowOffset: { width: 0, height: 0 },
     shadowOpacity: 0,

--- a/src/components/AppAlert.tsx
+++ b/src/components/AppAlert.tsx
@@ -1,0 +1,228 @@
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  Modal,
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  Animated,
+  Easing,
+} from 'react-native';
+import { colors } from '../constants/Colors';
+import { useLanguage } from '../contexts/LanguageContext';
+
+export type AppAlertButtonStyle = 'default' | 'cancel' | 'destructive';
+
+export interface AppAlertButton {
+  text: string;
+  onPress?: () => void;
+  style?: AppAlertButtonStyle;
+}
+
+interface AppAlertState {
+  visible: boolean;
+  title: string;
+  message?: string;
+  buttons?: AppAlertButton[];
+}
+
+type Listener = (state: AppAlertState) => void;
+
+let currentState: AppAlertState = { visible: false, title: '' };
+const listeners = new Set<Listener>();
+const emit = () => {
+  for (const l of listeners) l(currentState);
+};
+
+export const AppAlert = {
+  show(title: string, message?: string, buttons?: AppAlertButton[]) {
+    currentState = { visible: true, title, message, buttons };
+    emit();
+  },
+  hide() {
+    currentState = { ...currentState, visible: false };
+    emit();
+  },
+};
+
+export const AppAlertHost: React.FC = () => {
+  const [state, setLocal] = useState<AppAlertState>(currentState);
+  const fade = useRef(new Animated.Value(0)).current;
+  const scale = useRef(new Animated.Value(0.94)).current;
+  const { t } = useLanguage();
+
+  useEffect(() => {
+    const l: Listener = (s) => setLocal(s);
+    listeners.add(l);
+    return () => {
+      listeners.delete(l);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (state.visible) {
+      fade.setValue(0);
+      scale.setValue(0.94);
+      Animated.parallel([
+        Animated.timing(fade, {
+          toValue: 1,
+          duration: 160,
+          useNativeDriver: true,
+          easing: Easing.out(Easing.quad),
+        }),
+        Animated.spring(scale, {
+          toValue: 1,
+          useNativeDriver: true,
+          friction: 8,
+          tension: 90,
+        }),
+      ]).start();
+    }
+  }, [state.visible, fade, scale]);
+
+  const buttons: AppAlertButton[] =
+    state.buttons && state.buttons.length > 0
+      ? state.buttons
+      : [{ text: t('OK'), style: 'default' }];
+
+  const handlePress = (btn: AppAlertButton) => {
+    AppAlert.hide();
+    if (btn.onPress) setTimeout(btn.onPress, 0);
+  };
+
+  const handleBackdrop = () => {
+    const cancel = buttons.find((b) => b.style === 'cancel');
+    if (cancel) handlePress(cancel);
+  };
+
+  const stacked = buttons.length > 2;
+
+  return (
+    <Modal
+      visible={state.visible}
+      transparent
+      animationType="none"
+      statusBarTranslucent
+      onRequestClose={handleBackdrop}
+    >
+      <TouchableOpacity
+        activeOpacity={1}
+        style={styles.overlay}
+        onPress={handleBackdrop}
+      >
+        <Animated.View
+          style={[styles.card, { opacity: fade, transform: [{ scale }] }]}
+          onStartShouldSetResponder={() => true}
+          onTouchEnd={(e) => e.stopPropagation()}
+        >
+          <Text style={styles.title}>{state.title}</Text>
+          {state.message ? (
+            <Text style={styles.message}>{state.message}</Text>
+          ) : null}
+          <View
+            style={[styles.buttonsRow, stacked && styles.buttonsStacked]}
+          >
+            {buttons.map((btn, i) => {
+              const isDestructive = btn.style === 'destructive';
+              const isCancel = btn.style === 'cancel';
+              return (
+                <TouchableOpacity
+                  key={`${btn.text}-${i}`}
+                  style={[
+                    styles.button,
+                    stacked && styles.buttonStacked,
+                    isDestructive && styles.buttonDestructive,
+                    isCancel && styles.buttonCancel,
+                  ]}
+                  onPress={() => handlePress(btn)}
+                  activeOpacity={0.7}
+                >
+                  <Text
+                    style={[
+                      styles.buttonText,
+                      isCancel && styles.buttonTextCancel,
+                    ]}
+                  >
+                    {btn.text}
+                  </Text>
+                </TouchableOpacity>
+              );
+            })}
+          </View>
+        </Animated.View>
+      </TouchableOpacity>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  button: {
+    alignItems: 'center',
+    backgroundColor: colors.light.primary,
+    borderRadius: 10,
+    flex: 1,
+    justifyContent: 'center',
+    paddingVertical: 12,
+  },
+  buttonCancel: {
+    backgroundColor: colors.neutral.grey2,
+  },
+  buttonDestructive: {
+    backgroundColor: colors.light.alertRed,
+  },
+  buttonStacked: {
+    flex: 0,
+  },
+  buttonText: {
+    color: colors.neutral.white,
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  buttonTextCancel: {
+    color: colors.light.text,
+  },
+  buttonsRow: {
+    flexDirection: 'row',
+    gap: 10,
+    marginTop: 20,
+  },
+  buttonsStacked: {
+    flexDirection: 'column',
+  },
+  card: {
+    backgroundColor: colors.light.background,
+    borderRadius: 18,
+    elevation: 12,
+    maxWidth: 360,
+    paddingBottom: 18,
+    paddingHorizontal: 22,
+    paddingTop: 22,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.18,
+    shadowRadius: 24,
+    width: '100%',
+  },
+  message: {
+    color: colors.light.text,
+    fontSize: 14,
+    lineHeight: 20,
+    marginTop: 8,
+    textAlign: 'center',
+  },
+  overlay: {
+    alignItems: 'center',
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    flex: 1,
+    justifyContent: 'center',
+    padding: 24,
+  },
+  title: {
+    color: colors.light.primary,
+    fontSize: 17,
+    fontWeight: '700',
+    textAlign: 'center',
+  },
+});
+
+export default AppAlert;

--- a/src/components/AppAlert.tsx
+++ b/src/components/AppAlert.tsx
@@ -95,6 +95,12 @@ export const AppAlertHost: React.FC = () => {
     if (cancel) handlePress(cancel);
   };
 
+  const handleRequestClose = () => {
+    const cancel = buttons.find((b) => b.style === 'cancel');
+    if (cancel) handlePress(cancel);
+    else AppAlert.hide();
+  };
+
   const stacked = buttons.length > 2;
 
   return (
@@ -103,7 +109,7 @@ export const AppAlertHost: React.FC = () => {
       transparent
       animationType="none"
       statusBarTranslucent
-      onRequestClose={handleBackdrop}
+      onRequestClose={handleRequestClose}
     >
       <TouchableOpacity
         activeOpacity={1}

--- a/src/components/ChallengePage.tsx
+++ b/src/components/ChallengePage.tsx
@@ -6,7 +6,7 @@ import { colors } from "../constants/Colors";
 import { ChallengeCard, ShareExperience } from "./Challenge";
 import { useLanguage } from "../contexts/LanguageContext";
 import { ChallengeSkeleton } from "./Skeleton";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { challengeService } from "../services/challengeService";
 import { usePastChallenges } from "../hooks/usePastChallenges";
 import { useFeaturedPiece } from "../hooks/useEsploraHome";
@@ -15,7 +15,6 @@ import { RelatedPieceCard } from "./esplora/RelatedPieceCard";
 import { useFetchChallengePosts } from "../hooks/useFetchChallengePosts";
 import Post from "./Post";
 import { User } from "../models/User";
-import { Post as PostType } from "../types";
 
 interface ChallengePageProps {
   id?: number;
@@ -24,7 +23,6 @@ interface ChallengePageProps {
 export const ChallengePage: React.FC<ChallengePageProps> = ({ id }) => {
   const { t, language } = useLanguage();
   const params = useLocalSearchParams();
-  const queryClient = useQueryClient();
 
   const challengeId = id ?? (params.id ? parseInt(String(params.id)) : undefined);
 
@@ -142,30 +140,6 @@ export const ChallengePage: React.FC<ChallengePageProps> = ({ id }) => {
     setRefreshing(false);
   }, [refetch, refetchPastChallengePosts]);
 
-  const handlePostDeleted = useCallback((post: PostType) => {
-    type ChallengePostsPage = { posts: PostType[]; hasMore: boolean };
-    type ChallengePostsData = { pages: ChallengePostsPage[]; pageParams: number[] };
-
-    queryClient.setQueriesData<ChallengePostsData>({ queryKey: ["challenge-posts", challengeId] }, (oldData) => {
-      if (!oldData) return oldData;
-      return {
-        ...oldData,
-        pages: oldData.pages.map((page) => ({
-          ...page,
-          posts: page.posts.filter((pagePost) => pagePost.id !== post.id),
-        })),
-      };
-    });
-
-    if (post.challenge_id) {
-      queryClient.invalidateQueries({ queryKey: ["challenge-completion", post.challenge_id] });
-    }
-
-    if (post.quest_id) {
-      queryClient.invalidateQueries({ queryKey: ["quest-completion", post.quest_id] });
-    }
-  }, [challengeId, queryClient]);
-
   if (isLoading) {
     return <ChallengeSkeleton />;
   }
@@ -194,7 +168,7 @@ export const ChallengePage: React.FC<ChallengePageProps> = ({ id }) => {
         renderItem={({ item }) => {
           const postUser = pastChallengeUserMap[item.user_id] as User;
           if (!postUser) return null;
-          return <Post post={item} postUser={postUser} onPostDeleted={handlePostDeleted} />;
+          return <Post post={item} postUser={postUser} />;
         }}
         keyExtractor={(item) => String(item.id)}
         ListHeaderComponent={header}

--- a/src/components/Comments.tsx
+++ b/src/components/Comments.tsx
@@ -32,7 +32,6 @@ import { useLikes } from "../contexts/LikesContext";
 import { useReactions } from "../contexts/ReactionsContext";
 import { ReactionsBar } from "./ReactionsBar";
 import { ActionsMenu } from "./ActionsMenu";
-import { MenuProvider } from "react-native-popup-menu";
 import { captureEvent } from "../lib/posthog";
 import { COMMENT_EVENTS } from "../constants/analyticsEvents";
 import { translationService } from "../services/translationService";
@@ -370,34 +369,32 @@ export const CommentsModal: React.FC<CommentsProps> = ({
   }, [initialComments]);
 
   return (
-    <MenuProvider skipInstanceCheck>
-      <Animated.View
-        style={[
-          containerStyle,
-          {
-            transform: [{ translateY }],
-          },
-        ]}
-      >
-        <SafeAreaView style={safeAreaStyle}>
-          <View {...panResponder.panHandlers} style={dragHandleStyle}>
-            <View style={dragIndicatorStyle} />
-          </View>
+    <Animated.View
+      style={[
+        containerStyle,
+        {
+          transform: [{ translateY }],
+        },
+      ]}
+    >
+      <SafeAreaView style={safeAreaStyle}>
+        <View {...panResponder.panHandlers} style={dragHandleStyle}>
+          <View style={dragIndicatorStyle} />
+        </View>
 
-          <CommentsList
-            comments={comments}
-            loading={loading}
-            flatListRef={flatListRef}
-            onClose={onClose}
-            postId={postId}
-            postUserId={postUserId}
-            onCommentAdded={onCommentAdded}
-            addComment={addComment}
-            isAddingComment={isAddingComment}
-          />
-        </SafeAreaView>
-      </Animated.View>
-    </MenuProvider>
+        <CommentsList
+          comments={comments}
+          loading={loading}
+          flatListRef={flatListRef}
+          onClose={onClose}
+          postId={postId}
+          postUserId={postUserId}
+          onCommentAdded={onCommentAdded}
+          addComment={addComment}
+          isAddingComment={isAddingComment}
+        />
+      </SafeAreaView>
+    </Animated.View>
   );
 };
 

--- a/src/components/Comments.tsx
+++ b/src/components/Comments.tsx
@@ -11,7 +11,6 @@ import {
   ViewStyle,
   TextStyle,
   ImageStyle,
-  Dimensions,
   ActivityIndicator,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -542,7 +541,6 @@ const Comment: React.FC<CommentProps> = ({
               contentId={id}
               contentUserId={userId}
               onDelete={onCommentDeleted}
-              menuOffset={-Dimensions.get("window").height * 0.25 + 20}
             >
               <MaterialCommunityIcons name="dots-horizontal" size={18} color={colors.neutral.grey1} />
             </ActionsMenu>

--- a/src/components/Comments.tsx
+++ b/src/components/Comments.tsx
@@ -544,7 +544,7 @@ const Comment: React.FC<CommentProps> = ({
               onDelete={onCommentDeleted}
               menuOffset={-Dimensions.get("window").height * 0.25 + 20}
             >
-              <Icon name="ellipsis-h" size={14} color={colors.neutral.grey1} />
+              <MaterialCommunityIcons name="dots-horizontal" size={18} color={colors.neutral.grey1} />
             </ActionsMenu>
           </View>
         </View>

--- a/src/components/CompletionBurst.tsx
+++ b/src/components/CompletionBurst.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Animated, Dimensions, Easing, StyleSheet, View } from 'react-native';
-import Svg, { Circle, Defs, Ellipse, LinearGradient, Mask, Path, RadialGradient, Rect, Stop } from 'react-native-svg';
+import Svg, { Circle, Defs, Ellipse, LinearGradient, Path, RadialGradient, Rect, Stop } from 'react-native-svg';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import { Text } from './StyledText';
 import { colors } from '../constants/Colors';
@@ -12,23 +12,22 @@ const SWIRL_DURATION = 3400;
 const TROPHY_ROTATIONS = 4;
 const SPIRAL_REVOLUTIONS = 3.25;
 const SPIRAL_SAMPLES = 144;
-const TAIL_PADDING = 24;
-const TAIL_WIDTH_MIN = 3;
-const TAIL_WIDTH_MAX = 78;
+const TRAIL_DOT_COUNT = 110;
+const TRAIL_DOT_MIN = 4;
+const TRAIL_DOT_MAX = 56;
+
+type TrailDot = {
+  x: number;
+  y: number;
+  size: number;
+  threshold: number;
+};
 
 type SwirlPath = {
   input: number[];
   xs: number[];
   ys: number[];
-  d: string;
-  polygonD: string;
-  length: number;
-  dashoffsetOutput: number[];
-  maskStrokeWidth: number;
-  svgWidth: number;
-  svgHeight: number;
-  svgLeft: number;
-  svgTop: number;
+  dots: TrailDot[];
 };
 
 const buildSwirlPath = (): SwirlPath => {
@@ -38,7 +37,6 @@ const buildSwirlPath = (): SwirlPath => {
   const input: number[] = [];
   const xs: number[] = [];
   const ys: number[] = [];
-  const widths: number[] = [];
   for (let i = 0; i <= SPIRAL_SAMPLES; i++) {
     const p = i / SPIRAL_SAMPLES;
     const radiusFactor = Math.pow(1 - p, 1.6);
@@ -46,77 +44,36 @@ const buildSwirlPath = (): SwirlPath => {
     input.push(p);
     xs.push(Math.cos(angle) * maxRadiusX * radiusFactor);
     ys.push(Math.sin(angle) * maxRadiusY * radiusFactor);
-    widths.push(TAIL_WIDTH_MIN + (TAIL_WIDTH_MAX - TAIL_WIDTH_MIN) * p);
   }
   xs[xs.length - 1] = 0;
   ys[ys.length - 1] = 0;
 
-  const svgWidth = maxRadiusX * 2 + TAIL_PADDING * 2 + TAIL_WIDTH_MAX;
-  const svgHeight = maxRadiusY * 2 + TAIL_PADDING * 2 + TAIL_WIDTH_MAX;
-  const offsetX = maxRadiusX + TAIL_PADDING + TAIL_WIDTH_MAX / 2;
-  const offsetY = maxRadiusY + TAIL_PADDING + TAIL_WIDTH_MAX / 2;
-
-  let d = `M ${xs[0] + offsetX} ${ys[0] + offsetY}`;
-  const cumLengths: number[] = [0];
+  const cumLen: number[] = [0];
   for (let i = 1; i < xs.length; i++) {
-    d += ` L ${xs[i] + offsetX} ${ys[i] + offsetY}`;
-    cumLengths.push(
-      cumLengths[i - 1] + Math.hypot(xs[i] - xs[i - 1], ys[i] - ys[i - 1])
-    );
+    cumLen.push(cumLen[i - 1] + Math.hypot(xs[i] - xs[i - 1], ys[i] - ys[i - 1]));
   }
-  const length = cumLengths[cumLengths.length - 1];
-  const dashoffsetOutput = cumLengths.map(c => length - c);
+  const totalLen = cumLen[cumLen.length - 1];
 
-  const N = xs.length;
-  const outerPts: [number, number][] = new Array(N);
-  const innerPts: [number, number][] = new Array(N);
-  for (let i = 0; i < N; i++) {
-    let dx: number;
-    let dy: number;
-    if (i === 0) {
-      dx = xs[1] - xs[0];
-      dy = ys[1] - ys[0];
-    } else if (i === N - 1) {
-      dx = xs[i] - xs[i - 1];
-      dy = ys[i] - ys[i - 1];
-    } else {
-      dx = xs[i + 1] - xs[i - 1];
-      dy = ys[i + 1] - ys[i - 1];
-    }
-    const tLen = Math.hypot(dx, dy) || 1;
-    const nx = -dy / tLen;
-    const ny = dx / tLen;
-    const hw = widths[i] / 2;
-    outerPts[i] = [xs[i] + nx * hw + offsetX, ys[i] + ny * hw + offsetY];
-    innerPts[i] = [xs[i] - nx * hw + offsetX, ys[i] - ny * hw + offsetY];
+  const dots: TrailDot[] = [];
+  let j = 0;
+  for (let i = 0; i < TRAIL_DOT_COUNT; i++) {
+    const targetLen = (i / (TRAIL_DOT_COUNT - 1)) * totalLen;
+    while (j < cumLen.length - 2 && cumLen[j + 1] < targetLen) j++;
+    const segLen = cumLen[j + 1] - cumLen[j] || 1;
+    const t = (targetLen - cumLen[j]) / segLen;
+    const x = xs[j] + (xs[j + 1] - xs[j]) * t;
+    const y = ys[j] + (ys[j + 1] - ys[j]) * t;
+    const p = input[j] + (input[j + 1] - input[j]) * t;
+    dots.push({
+      x,
+      y,
+      size: TRAIL_DOT_MIN + (TRAIL_DOT_MAX - TRAIL_DOT_MIN) * p,
+      threshold: p,
+    });
   }
 
-  let polygonD = `M ${outerPts[0][0]} ${outerPts[0][1]}`;
-  for (let i = 1; i < N; i++) {
-    polygonD += ` L ${outerPts[i][0]} ${outerPts[i][1]}`;
-  }
-  for (let i = N - 1; i >= 0; i--) {
-    polygonD += ` L ${innerPts[i][0]} ${innerPts[i][1]}`;
-  }
-  polygonD += ' Z';
-
-  return {
-    input,
-    xs,
-    ys,
-    d,
-    polygonD,
-    length,
-    dashoffsetOutput,
-    maskStrokeWidth: TAIL_WIDTH_MAX + 6,
-    svgWidth,
-    svgHeight,
-    svgLeft: (BURST_SIZE - svgWidth) / 2,
-    svgTop: (BURST_SIZE - svgHeight) / 2,
-  };
+  return { input, xs, ys, dots };
 };
-
-const AnimatedPath = Animated.createAnimatedComponent(Path);
 
 interface CompletionBurstProps {
   title: string;
@@ -251,6 +208,58 @@ const Sparkle: React.FC<{ index: number; trigger: number }> = ({ index, trigger 
   );
 };
 
+const TrailDot: React.FC<{
+  dot: TrailDot;
+  trophyProgress: Animated.Value;
+  tailOpacity: Animated.Value;
+}> = ({ dot, trophyProgress, tailOpacity }) => {
+  const ramp = 0.03;
+  const fade = 0.22;
+  const peakIn = dot.threshold;
+  const peakOut = Math.min(1, peakIn + fade);
+  const inputRange: number[] = [];
+  const outputRange: number[] = [];
+  if (peakIn > 0) {
+    const start = Math.max(0, peakIn - ramp);
+    if (start < peakIn) {
+      inputRange.push(start);
+      outputRange.push(0);
+    }
+  }
+  inputRange.push(peakIn);
+  outputRange.push(1);
+  if (peakOut > peakIn) {
+    inputRange.push(peakOut);
+    outputRange.push(0);
+  }
+  if (peakOut < 1) {
+    inputRange.push(1);
+    outputRange.push(0);
+  }
+  const reveal = trophyProgress.interpolate({
+    inputRange,
+    outputRange,
+    extrapolate: 'clamp',
+  });
+  const opacity = Animated.multiply(reveal, tailOpacity);
+  const half = dot.size / 2;
+  return (
+    <Animated.View
+      pointerEvents="none"
+      style={{
+        position: 'absolute',
+        left: BURST_SIZE / 2 + dot.x - half,
+        top: BURST_SIZE / 2 + dot.y - half,
+        width: dot.size,
+        height: dot.size,
+        borderRadius: half,
+        backgroundColor: '#FFE27A',
+        opacity,
+      }}
+    />
+  );
+};
+
 const Trophy: React.FC<{ size: number }> = ({ size }) => (
   <Svg width={size} height={size} viewBox="0 0 100 100">
     <Defs>
@@ -359,19 +368,11 @@ const CompletionBurst: React.FC<CompletionBurstProps> = ({ title }) => {
 
   const glowPulse = useRef(new Animated.Value(0)).current;
   const titleProgress = useRef(new Animated.Value(0)).current;
-  const tailProgress = useRef(new Animated.Value(0)).current;
   const tailOpacity = useRef(new Animated.Value(1)).current;
   const [burstKey, setBurstKey] = useState(0);
 
   useEffect(() => {
     const loops: Animated.CompositeAnimation[] = [];
-
-    Animated.timing(tailProgress, {
-      toValue: 1,
-      duration: SWIRL_DURATION,
-      easing: Easing.bezier(0.32, 0, 0.32, 1),
-      useNativeDriver: false,
-    }).start();
 
     Animated.parallel([
       Animated.timing(trophyProgress, {
@@ -396,9 +397,9 @@ const CompletionBurst: React.FC<CompletionBurstProps> = ({ title }) => {
 
       Animated.timing(tailOpacity, {
         toValue: 0,
-        duration: 220,
+        duration: 320,
         easing: Easing.out(Easing.quad),
-        useNativeDriver: false,
+        useNativeDriver: true,
       }).start();
 
       ringOpacity.setValue(1);
@@ -518,7 +519,7 @@ const CompletionBurst: React.FC<CompletionBurstProps> = ({ title }) => {
     return () => {
       loops.forEach(l => l.stop());
     };
-  }, [trophyProgress, trophyScale, bob, raysScale, raysOpacity, raysRotate, ringScale, ringOpacity, ringScale2, ringOpacity2, glowPulse, titleProgress, tailProgress, tailOpacity]);
+  }, [trophyProgress, trophyScale, bob, raysScale, raysOpacity, raysRotate, ringScale, ringOpacity, ringScale2, ringOpacity2, glowPulse, titleProgress, tailOpacity]);
 
   const tx = trophyProgress.interpolate({ inputRange: swirlPath.input, outputRange: swirlPath.xs });
   const ty = trophyProgress.interpolate({ inputRange: swirlPath.input, outputRange: swirlPath.ys });
@@ -538,11 +539,6 @@ const CompletionBurst: React.FC<CompletionBurstProps> = ({ title }) => {
   const glowFinal = Animated.multiply(raysOpacity, glowOpacity);
 
   const titleTranslate = titleProgress.interpolate({ inputRange: [0, 1], outputRange: [14, 0] });
-
-  const tailDashOffset = tailProgress.interpolate({
-    inputRange: swirlPath.input,
-    outputRange: swirlPath.dashoffsetOutput,
-  });
 
   return (
     <View style={styles.container} pointerEvents="none">
@@ -582,49 +578,14 @@ const CompletionBurst: React.FC<CompletionBurstProps> = ({ title }) => {
           <ShockRing />
         </Animated.View>
 
-        <Animated.View
-          pointerEvents="none"
-          style={{
-            position: 'absolute',
-            left: swirlPath.svgLeft,
-            top: swirlPath.svgTop,
-            width: swirlPath.svgWidth,
-            height: swirlPath.svgHeight,
-            opacity: tailOpacity,
-          }}
-        >
-          <Svg width={swirlPath.svgWidth} height={swirlPath.svgHeight}>
-            <Defs>
-              <Mask
-                id="tailMask"
-                maskUnits="userSpaceOnUse"
-                x="0"
-                y="0"
-                width={swirlPath.svgWidth}
-                height={swirlPath.svgHeight}
-              >
-                <Rect
-                  x="0"
-                  y="0"
-                  width={swirlPath.svgWidth}
-                  height={swirlPath.svgHeight}
-                  fill="black"
-                />
-                <AnimatedPath
-                  d={swirlPath.d}
-                  stroke="white"
-                  strokeWidth={swirlPath.maskStrokeWidth}
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  fill="none"
-                  strokeDasharray={`${swirlPath.length}, ${swirlPath.length}`}
-                  strokeDashoffset={tailDashOffset}
-                />
-              </Mask>
-            </Defs>
-            <Path d={swirlPath.polygonD} fill="#FFE27A" mask="url(#tailMask)" />
-          </Svg>
-        </Animated.View>
+        {swirlPath.dots.map((dot, i) => (
+          <TrailDot
+            key={`trail-${i}`}
+            dot={dot}
+            trophyProgress={trophyProgress}
+            tailOpacity={tailOpacity}
+          />
+        ))}
 
         <Animated.View
           style={[

--- a/src/components/CompletionBurst.tsx
+++ b/src/components/CompletionBurst.tsx
@@ -1,0 +1,705 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { Animated, Dimensions, Easing, StyleSheet, View } from 'react-native';
+import Svg, { Circle, Defs, Ellipse, LinearGradient, Mask, Path, RadialGradient, Rect, Stop } from 'react-native-svg';
+import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
+import { Text } from './StyledText';
+import { colors } from '../constants/Colors';
+
+const BURST_SIZE = 220;
+const RAY_COUNT = 18;
+const SPARKLE_COUNT = 14;
+const SWIRL_DURATION = 3400;
+const TROPHY_ROTATIONS = 4;
+const SPIRAL_REVOLUTIONS = 3.25;
+const SPIRAL_SAMPLES = 144;
+const TAIL_PADDING = 24;
+const TAIL_WIDTH_MIN = 3;
+const TAIL_WIDTH_MAX = 78;
+
+type SwirlPath = {
+  input: number[];
+  xs: number[];
+  ys: number[];
+  d: string;
+  polygonD: string;
+  length: number;
+  dashoffsetOutput: number[];
+  maskStrokeWidth: number;
+  svgWidth: number;
+  svgHeight: number;
+  svgLeft: number;
+  svgTop: number;
+};
+
+const buildSwirlPath = (): SwirlPath => {
+  const { width, height } = Dimensions.get('window');
+  const maxRadiusX = Math.min(width * 0.46, 220);
+  const maxRadiusY = Math.min(height * 0.36, 320);
+  const input: number[] = [];
+  const xs: number[] = [];
+  const ys: number[] = [];
+  const widths: number[] = [];
+  for (let i = 0; i <= SPIRAL_SAMPLES; i++) {
+    const p = i / SPIRAL_SAMPLES;
+    const radiusFactor = Math.pow(1 - p, 1.6);
+    const angle = p * SPIRAL_REVOLUTIONS * Math.PI * 2 - Math.PI / 2;
+    input.push(p);
+    xs.push(Math.cos(angle) * maxRadiusX * radiusFactor);
+    ys.push(Math.sin(angle) * maxRadiusY * radiusFactor);
+    widths.push(TAIL_WIDTH_MIN + (TAIL_WIDTH_MAX - TAIL_WIDTH_MIN) * p);
+  }
+  xs[xs.length - 1] = 0;
+  ys[ys.length - 1] = 0;
+
+  const svgWidth = maxRadiusX * 2 + TAIL_PADDING * 2 + TAIL_WIDTH_MAX;
+  const svgHeight = maxRadiusY * 2 + TAIL_PADDING * 2 + TAIL_WIDTH_MAX;
+  const offsetX = maxRadiusX + TAIL_PADDING + TAIL_WIDTH_MAX / 2;
+  const offsetY = maxRadiusY + TAIL_PADDING + TAIL_WIDTH_MAX / 2;
+
+  let d = `M ${xs[0] + offsetX} ${ys[0] + offsetY}`;
+  const cumLengths: number[] = [0];
+  for (let i = 1; i < xs.length; i++) {
+    d += ` L ${xs[i] + offsetX} ${ys[i] + offsetY}`;
+    cumLengths.push(
+      cumLengths[i - 1] + Math.hypot(xs[i] - xs[i - 1], ys[i] - ys[i - 1])
+    );
+  }
+  const length = cumLengths[cumLengths.length - 1];
+  const dashoffsetOutput = cumLengths.map(c => length - c);
+
+  const N = xs.length;
+  const outerPts: [number, number][] = new Array(N);
+  const innerPts: [number, number][] = new Array(N);
+  for (let i = 0; i < N; i++) {
+    let dx: number;
+    let dy: number;
+    if (i === 0) {
+      dx = xs[1] - xs[0];
+      dy = ys[1] - ys[0];
+    } else if (i === N - 1) {
+      dx = xs[i] - xs[i - 1];
+      dy = ys[i] - ys[i - 1];
+    } else {
+      dx = xs[i + 1] - xs[i - 1];
+      dy = ys[i + 1] - ys[i - 1];
+    }
+    const tLen = Math.hypot(dx, dy) || 1;
+    const nx = -dy / tLen;
+    const ny = dx / tLen;
+    const hw = widths[i] / 2;
+    outerPts[i] = [xs[i] + nx * hw + offsetX, ys[i] + ny * hw + offsetY];
+    innerPts[i] = [xs[i] - nx * hw + offsetX, ys[i] - ny * hw + offsetY];
+  }
+
+  let polygonD = `M ${outerPts[0][0]} ${outerPts[0][1]}`;
+  for (let i = 1; i < N; i++) {
+    polygonD += ` L ${outerPts[i][0]} ${outerPts[i][1]}`;
+  }
+  for (let i = N - 1; i >= 0; i--) {
+    polygonD += ` L ${innerPts[i][0]} ${innerPts[i][1]}`;
+  }
+  polygonD += ' Z';
+
+  return {
+    input,
+    xs,
+    ys,
+    d,
+    polygonD,
+    length,
+    dashoffsetOutput,
+    maskStrokeWidth: TAIL_WIDTH_MAX + 6,
+    svgWidth,
+    svgHeight,
+    svgLeft: (BURST_SIZE - svgWidth) / 2,
+    svgTop: (BURST_SIZE - svgHeight) / 2,
+  };
+};
+
+const AnimatedPath = Animated.createAnimatedComponent(Path);
+
+interface CompletionBurstProps {
+  title: string;
+}
+
+const Rays: React.FC = () => {
+  const paths = useMemo(() => {
+    const items: { d: string; fill: string }[] = [];
+    const cx = BURST_SIZE / 2;
+    const cy = BURST_SIZE / 2;
+    const inner = 42;
+    const outer = BURST_SIZE / 2;
+    const halfAngle = (Math.PI * 2) / RAY_COUNT / 4;
+    for (let i = 0; i < RAY_COUNT; i++) {
+      const a = (i / RAY_COUNT) * Math.PI * 2;
+      const x1 = cx + Math.cos(a - halfAngle) * inner;
+      const y1 = cy + Math.sin(a - halfAngle) * inner;
+      const x2 = cx + Math.cos(a) * outer;
+      const y2 = cy + Math.sin(a) * outer;
+      const x3 = cx + Math.cos(a + halfAngle) * inner;
+      const y3 = cy + Math.sin(a + halfAngle) * inner;
+      items.push({
+        d: `M ${x1} ${y1} L ${x2} ${y2} L ${x3} ${y3} Z`,
+        fill: i % 2 === 0 ? 'url(#rayGold)' : 'url(#rayAmber)',
+      });
+    }
+    return items;
+  }, []);
+
+  return (
+    <Svg width={BURST_SIZE} height={BURST_SIZE} viewBox={`0 0 ${BURST_SIZE} ${BURST_SIZE}`}>
+      <Defs>
+        <LinearGradient id="rayGold" x1="0.5" y1="0" x2="0.5" y2="1">
+          <Stop offset="0" stopColor="#FFE27A" stopOpacity="1" />
+          <Stop offset="1" stopColor="#FFB347" stopOpacity="0" />
+        </LinearGradient>
+        <LinearGradient id="rayAmber" x1="0.5" y1="0" x2="0.5" y2="1">
+          <Stop offset="0" stopColor="#FF9A4D" stopOpacity="0.95" />
+          <Stop offset="1" stopColor="#FF6B3D" stopOpacity="0" />
+        </LinearGradient>
+      </Defs>
+      {paths.map((p, i) => (
+        <Path key={i} d={p.d} fill={p.fill} />
+      ))}
+    </Svg>
+  );
+};
+
+const Glow: React.FC = () => (
+  <Svg width={BURST_SIZE} height={BURST_SIZE} viewBox={`0 0 ${BURST_SIZE} ${BURST_SIZE}`}>
+    <Defs>
+      <RadialGradient id="glow" cx="0.5" cy="0.5" r="0.5">
+        <Stop offset="0" stopColor="#FFE27A" stopOpacity="0.85" />
+        <Stop offset="0.45" stopColor="#FFB347" stopOpacity="0.28" />
+        <Stop offset="1" stopColor="#FF6B3D" stopOpacity="0" />
+      </RadialGradient>
+    </Defs>
+    <Rect x="0" y="0" width={BURST_SIZE} height={BURST_SIZE} fill="url(#glow)" />
+  </Svg>
+);
+
+const ShockRing: React.FC = () => (
+  <Svg width={BURST_SIZE} height={BURST_SIZE} viewBox={`0 0 ${BURST_SIZE} ${BURST_SIZE}`}>
+    <Circle
+      cx={BURST_SIZE / 2}
+      cy={BURST_SIZE / 2}
+      r={56}
+      fill="none"
+      stroke="#FFE27A"
+      strokeWidth={3}
+    />
+  </Svg>
+);
+
+const Sparkle: React.FC<{ index: number; trigger: number }> = ({ index, trigger }) => {
+  const progress = useRef(new Animated.Value(0)).current;
+  const angle = (index / SPARKLE_COUNT) * Math.PI * 2;
+  const distance = 95 + (index % 4) * 18;
+  const delay = index * 10;
+
+  useEffect(() => {
+    if (trigger === 0) return;
+    progress.setValue(0);
+    Animated.timing(progress, {
+      toValue: 1,
+      duration: 1050,
+      delay,
+      easing: Easing.out(Easing.cubic),
+      useNativeDriver: true,
+    }).start();
+  }, [trigger, progress, delay]);
+
+  const translateX = progress.interpolate({
+    inputRange: [0, 1],
+    outputRange: [0, Math.cos(angle) * distance],
+  });
+  const translateY = progress.interpolate({
+    inputRange: [0, 1],
+    outputRange: [0, Math.sin(angle) * distance],
+  });
+  const opacity = progress.interpolate({
+    inputRange: [0, 0.12, 0.7, 1],
+    outputRange: [0, 1, 1, 0],
+  });
+  const scale = progress.interpolate({
+    inputRange: [0, 0.3, 1],
+    outputRange: [0.3, 1.2, 0.4],
+  });
+
+  return (
+    <Animated.View
+      pointerEvents="none"
+      style={[
+        styles.sparkle,
+        {
+          opacity,
+          transform: [
+            { translateX },
+            { translateY },
+            { scale },
+            { rotate: `${index * 32}deg` },
+          ],
+        },
+      ]}
+    >
+      <MaterialCommunityIcons
+        name={index % 2 === 0 ? 'star-four-points' : 'star'}
+        size={16}
+        color={index % 3 === 0 ? '#FFFFFF' : '#FFE27A'}
+      />
+    </Animated.View>
+  );
+};
+
+const Trophy: React.FC<{ size: number }> = ({ size }) => (
+  <Svg width={size} height={size} viewBox="0 0 100 100">
+    <Defs>
+      <LinearGradient id="trGoldMain" x1="0" y1="0" x2="0" y2="1">
+        <Stop offset="0" stopColor="#FFF2A8" />
+        <Stop offset="0.35" stopColor="#F5C543" />
+        <Stop offset="1" stopColor="#8E5A14" />
+      </LinearGradient>
+      <LinearGradient id="trGoldHi" x1="0" y1="0" x2="0" y2="1">
+        <Stop offset="0" stopColor="#FFFBE0" />
+        <Stop offset="1" stopColor="#FFD970" />
+      </LinearGradient>
+      <LinearGradient id="trGoldSide" x1="0" y1="0" x2="1" y2="0">
+        <Stop offset="0" stopColor="#7A4A0E" stopOpacity="0.55" />
+        <Stop offset="0.5" stopColor="#F5C543" stopOpacity="0" />
+        <Stop offset="1" stopColor="#7A4A0E" stopOpacity="0.55" />
+      </LinearGradient>
+      <LinearGradient id="trBaseGrad" x1="0" y1="0" x2="0" y2="1">
+        <Stop offset="0" stopColor="#F5C543" />
+        <Stop offset="1" stopColor="#7A4A0E" />
+      </LinearGradient>
+    </Defs>
+
+    <Path
+      d="M 28 30 C 8 30, 8 62, 30 60 L 30 54 C 18 55, 18 37, 28 35 Z"
+      fill="url(#trGoldMain)"
+      stroke="#5C3A0A"
+      strokeWidth="0.6"
+    />
+    <Path
+      d="M 72 30 C 92 30, 92 62, 70 60 L 70 54 C 82 55, 82 37, 72 35 Z"
+      fill="url(#trGoldMain)"
+      stroke="#5C3A0A"
+      strokeWidth="0.6"
+    />
+
+    <Path
+      d="M 22 22 L 78 22 L 74 56 C 72 64, 60 70, 50 70 C 40 70, 28 64, 26 56 Z"
+      fill="url(#trGoldMain)"
+      stroke="#5C3A0A"
+      strokeWidth="0.7"
+    />
+    <Path
+      d="M 22 22 L 78 22 L 74 56 C 72 64, 60 70, 50 70 C 40 70, 28 64, 26 56 Z"
+      fill="url(#trGoldSide)"
+    />
+
+    <Path
+      d="M 20 19 L 80 19 L 78 27 L 22 27 Z"
+      fill="url(#trGoldHi)"
+      stroke="#5C3A0A"
+      strokeWidth="0.6"
+    />
+    <Ellipse cx="50" cy="22" rx="27" ry="3.2" fill="#3D2806" opacity="0.6" />
+    <Ellipse cx="50" cy="22" rx="22" ry="1.6" fill="#FFFBE0" opacity="0.4" />
+
+    <Path d="M 33 30 L 32 58 L 37 58 L 38.5 30 Z" fill="#FFFBE0" opacity="0.5" />
+    <Path d="M 60 30 L 60 55 L 62 55 L 62.5 30 Z" fill="#7A4A0E" opacity="0.35" />
+
+    <Path
+      d="M 44 70 L 56 70 L 55 78 L 45 78 Z"
+      fill="url(#trGoldMain)"
+      stroke="#5C3A0A"
+      strokeWidth="0.5"
+    />
+    <Path d="M 46 71 L 47 77 L 48 77 L 48 71 Z" fill="#FFFBE0" opacity="0.55" />
+
+    <Ellipse
+      cx="50"
+      cy="78"
+      rx="11"
+      ry="2.6"
+      fill="url(#trGoldHi)"
+      stroke="#5C3A0A"
+      strokeWidth="0.5"
+    />
+
+    <Path
+      d="M 26 81 L 74 81 L 70 93 L 30 93 Z"
+      fill="url(#trBaseGrad)"
+      stroke="#5C3A0A"
+      strokeWidth="0.7"
+    />
+    <Path d="M 28 81 L 72 81 L 70.5 84.5 L 29.5 84.5 Z" fill="url(#trGoldHi)" />
+    <Path
+      d="M 26 81 L 74 81 L 70 93 L 30 93 Z"
+      fill="url(#trGoldSide)"
+    />
+  </Svg>
+);
+
+const CompletionBurst: React.FC<CompletionBurstProps> = ({ title }) => {
+  const swirlPath = useMemo(buildSwirlPath, []);
+  const trophyProgress = useRef(new Animated.Value(0)).current;
+  const trophyScale = useRef(new Animated.Value(0.2)).current;
+  const bob = useRef(new Animated.Value(0)).current;
+
+  const raysScale = useRef(new Animated.Value(0)).current;
+  const raysOpacity = useRef(new Animated.Value(0)).current;
+  const raysRotate = useRef(new Animated.Value(0)).current;
+
+  const ringScale = useRef(new Animated.Value(0.4)).current;
+  const ringOpacity = useRef(new Animated.Value(0)).current;
+  const ringScale2 = useRef(new Animated.Value(0.4)).current;
+  const ringOpacity2 = useRef(new Animated.Value(0)).current;
+
+  const glowPulse = useRef(new Animated.Value(0)).current;
+  const titleProgress = useRef(new Animated.Value(0)).current;
+  const tailProgress = useRef(new Animated.Value(0)).current;
+  const tailOpacity = useRef(new Animated.Value(1)).current;
+  const [burstKey, setBurstKey] = useState(0);
+
+  useEffect(() => {
+    const loops: Animated.CompositeAnimation[] = [];
+
+    Animated.timing(tailProgress, {
+      toValue: 1,
+      duration: SWIRL_DURATION,
+      easing: Easing.bezier(0.32, 0, 0.32, 1),
+      useNativeDriver: false,
+    }).start();
+
+    Animated.parallel([
+      Animated.timing(trophyProgress, {
+        toValue: 1,
+        duration: SWIRL_DURATION,
+        easing: Easing.bezier(0.32, 0, 0.32, 1),
+        useNativeDriver: true,
+      }),
+      Animated.timing(trophyScale, {
+        toValue: 0.88,
+        duration: SWIRL_DURATION - 80,
+        easing: Easing.out(Easing.cubic),
+        useNativeDriver: true,
+      }),
+    ]).start(() => {
+      Animated.spring(trophyScale, {
+        toValue: 1,
+        friction: 3.5,
+        tension: 150,
+        useNativeDriver: true,
+      }).start();
+
+      Animated.timing(tailOpacity, {
+        toValue: 0,
+        duration: 220,
+        easing: Easing.out(Easing.quad),
+        useNativeDriver: false,
+      }).start();
+
+      ringOpacity.setValue(1);
+      Animated.parallel([
+        Animated.timing(ringScale, {
+          toValue: 2.4,
+          duration: 720,
+          easing: Easing.out(Easing.cubic),
+          useNativeDriver: true,
+        }),
+        Animated.timing(ringOpacity, {
+          toValue: 0,
+          duration: 720,
+          easing: Easing.out(Easing.quad),
+          useNativeDriver: true,
+        }),
+      ]).start();
+
+      Animated.sequence([
+        Animated.delay(90),
+        Animated.parallel([
+          Animated.timing(ringScale2, {
+            toValue: 2.0,
+            duration: 620,
+            easing: Easing.out(Easing.cubic),
+            useNativeDriver: true,
+          }),
+          Animated.sequence([
+            Animated.timing(ringOpacity2, {
+              toValue: 1,
+              duration: 0,
+              useNativeDriver: true,
+            }),
+            Animated.timing(ringOpacity2, {
+              toValue: 0,
+              duration: 620,
+              easing: Easing.out(Easing.quad),
+              useNativeDriver: true,
+            }),
+          ]),
+        ]),
+      ]).start();
+
+      Animated.parallel([
+        Animated.spring(raysScale, {
+          toValue: 1,
+          friction: 5,
+          tension: 80,
+          useNativeDriver: true,
+        }),
+        Animated.timing(raysOpacity, {
+          toValue: 1,
+          duration: 320,
+          useNativeDriver: true,
+        }),
+      ]).start();
+
+      const rayLoop = Animated.loop(
+        Animated.timing(raysRotate, {
+          toValue: 1,
+          duration: 16000,
+          easing: Easing.linear,
+          useNativeDriver: true,
+        })
+      );
+      rayLoop.start();
+      loops.push(rayLoop);
+
+      const pulseLoop = Animated.loop(
+        Animated.sequence([
+          Animated.timing(glowPulse, {
+            toValue: 1,
+            duration: 1300,
+            easing: Easing.inOut(Easing.quad),
+            useNativeDriver: true,
+          }),
+          Animated.timing(glowPulse, {
+            toValue: 0,
+            duration: 1300,
+            easing: Easing.inOut(Easing.quad),
+            useNativeDriver: true,
+          }),
+        ])
+      );
+      pulseLoop.start();
+      loops.push(pulseLoop);
+
+      const bobLoop = Animated.loop(
+        Animated.sequence([
+          Animated.timing(bob, {
+            toValue: 1,
+            duration: 1700,
+            easing: Easing.inOut(Easing.sin),
+            useNativeDriver: true,
+          }),
+          Animated.timing(bob, {
+            toValue: 0,
+            duration: 1700,
+            easing: Easing.inOut(Easing.sin),
+            useNativeDriver: true,
+          }),
+        ])
+      );
+      bobLoop.start();
+      loops.push(bobLoop);
+
+      setBurstKey(k => k + 1);
+
+      Animated.spring(titleProgress, {
+        toValue: 1,
+        friction: 7,
+        tension: 80,
+        useNativeDriver: true,
+      }).start();
+    });
+
+    return () => {
+      loops.forEach(l => l.stop());
+    };
+  }, [trophyProgress, trophyScale, bob, raysScale, raysOpacity, raysRotate, ringScale, ringOpacity, ringScale2, ringOpacity2, glowPulse, titleProgress, tailProgress, tailOpacity]);
+
+  const tx = trophyProgress.interpolate({ inputRange: swirlPath.input, outputRange: swirlPath.xs });
+  const ty = trophyProgress.interpolate({ inputRange: swirlPath.input, outputRange: swirlPath.ys });
+  const trophyRotate = trophyProgress.interpolate({
+    inputRange: [0, 1],
+    outputRange: ['-30deg', `${TROPHY_ROTATIONS * 360}deg`],
+  });
+  const bobY = bob.interpolate({ inputRange: [0, 1], outputRange: [0, -6] });
+  const combinedY = Animated.add(ty, bobY);
+
+  const rotateInterp = raysRotate.interpolate({
+    inputRange: [0, 1],
+    outputRange: ['0deg', '360deg'],
+  });
+  const glowScale = glowPulse.interpolate({ inputRange: [0, 1], outputRange: [0.92, 1.1] });
+  const glowOpacity = glowPulse.interpolate({ inputRange: [0, 1], outputRange: [0.6, 1] });
+  const glowFinal = Animated.multiply(raysOpacity, glowOpacity);
+
+  const titleTranslate = titleProgress.interpolate({ inputRange: [0, 1], outputRange: [14, 0] });
+
+  const tailDashOffset = tailProgress.interpolate({
+    inputRange: swirlPath.input,
+    outputRange: swirlPath.dashoffsetOutput,
+  });
+
+  return (
+    <View style={styles.container} pointerEvents="none">
+      <View style={styles.burst}>
+        <Animated.View
+          style={[
+            styles.layer,
+            { opacity: raysOpacity, transform: [{ rotate: rotateInterp }, { scale: raysScale }] },
+          ]}
+        >
+          <Rays />
+        </Animated.View>
+
+        <Animated.View
+          style={[
+            styles.layer,
+            { opacity: glowFinal, transform: [{ scale: glowScale }] },
+          ]}
+        >
+          <Glow />
+        </Animated.View>
+
+        <Animated.View
+          style={[
+            styles.layer,
+            { opacity: ringOpacity, transform: [{ scale: ringScale }] },
+          ]}
+        >
+          <ShockRing />
+        </Animated.View>
+        <Animated.View
+          style={[
+            styles.layer,
+            { opacity: ringOpacity2, transform: [{ scale: ringScale2 }] },
+          ]}
+        >
+          <ShockRing />
+        </Animated.View>
+
+        <Animated.View
+          pointerEvents="none"
+          style={{
+            position: 'absolute',
+            left: swirlPath.svgLeft,
+            top: swirlPath.svgTop,
+            width: swirlPath.svgWidth,
+            height: swirlPath.svgHeight,
+            opacity: tailOpacity,
+          }}
+        >
+          <Svg width={swirlPath.svgWidth} height={swirlPath.svgHeight}>
+            <Defs>
+              <Mask
+                id="tailMask"
+                maskUnits="userSpaceOnUse"
+                x="0"
+                y="0"
+                width={swirlPath.svgWidth}
+                height={swirlPath.svgHeight}
+              >
+                <Rect
+                  x="0"
+                  y="0"
+                  width={swirlPath.svgWidth}
+                  height={swirlPath.svgHeight}
+                  fill="black"
+                />
+                <AnimatedPath
+                  d={swirlPath.d}
+                  stroke="white"
+                  strokeWidth={swirlPath.maskStrokeWidth}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  fill="none"
+                  strokeDasharray={`${swirlPath.length}, ${swirlPath.length}`}
+                  strokeDashoffset={tailDashOffset}
+                />
+              </Mask>
+            </Defs>
+            <Path d={swirlPath.polygonD} fill="#FFE27A" mask="url(#tailMask)" />
+          </Svg>
+        </Animated.View>
+
+        <Animated.View
+          style={[
+            styles.hero,
+            {
+              transform: [
+                { translateX: tx },
+                { translateY: combinedY },
+                { rotate: trophyRotate },
+                { scale: trophyScale },
+              ],
+            },
+          ]}
+        >
+          <View style={styles.heroInner}>
+            <Trophy size={88} />
+          </View>
+        </Animated.View>
+
+        {Array.from({ length: SPARKLE_COUNT }).map((_, i) => (
+          <Sparkle key={`sparkle-${burstKey}-${i}`} index={i} trigger={burstKey} />
+        ))}
+      </View>
+
+      <Animated.View
+        style={{
+          opacity: titleProgress,
+          transform: [{ translateY: titleTranslate }, { scale: titleProgress }],
+        }}
+      >
+        <Text style={styles.title}>{title}</Text>
+      </Animated.View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  burst: {
+    alignItems: 'center',
+    height: BURST_SIZE,
+    justifyContent: 'center',
+    overflow: 'visible',
+    width: BURST_SIZE,
+  },
+  container: {
+    alignItems: 'center',
+  },
+  hero: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    position: 'absolute',
+    shadowColor: '#FF9A4D',
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.5,
+    shadowRadius: 18,
+  },
+  heroInner: {
+    alignItems: 'center',
+    height: 88,
+    justifyContent: 'center',
+    width: 88,
+  },
+  layer: {
+    position: 'absolute',
+  },
+  sparkle: {
+    position: 'absolute',
+  },
+  title: {
+    color: colors.light.text,
+    fontSize: 26,
+    fontWeight: 'bold',
+    marginTop: 8,
+    textAlign: 'center',
+  },
+});
+
+export default CompletionBurst;

--- a/src/components/Post.tsx
+++ b/src/components/Post.tsx
@@ -45,6 +45,7 @@ import { POST_EVENTS, COMMENT_EVENTS } from "../constants/analyticsEvents";
 import { sendCommentNotification } from "../lib/notificationsService";
 import { translationService } from "../services/translationService";
 import { useInstagramShare } from "../hooks/useInstagramShare";
+import { usePostDeleteCleanup } from "../hooks/usePostDeleteCleanup";
 import InstagramStoryCard from "./InstagramStoryCard";
 
 interface PostProps {
@@ -62,6 +63,7 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
   const { likedPosts, likeCounts, togglePostLike } = useLikes();
   const { postReactions, togglePostReaction } = useReactions();
   const { user, isAdmin, username: currentUserUsername } = useAuth();
+  const cleanupAfterDelete = usePostDeleteCleanup();
   const [showComments, setShowComments] = useState(false);
   const [translatedText, setTranslatedText] = useState<string | null>(null);
   const [isTranslating, setIsTranslating] = useState(false);
@@ -456,6 +458,7 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
           contentId={post.id}
           contentUserId={post.user_id}
           onDelete={() => {
+            cleanupAfterDelete(post);
             onPostDeleted?.(post);
             if (isPostPage) {
               router.back();

--- a/src/components/Post.tsx
+++ b/src/components/Post.tsx
@@ -471,7 +471,7 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
   return (
     <Animated.View
       onLayout={(e) => {
-        if (containerHeight == null) {
+        if (!isDeleting) {
           setContainerHeight(e.nativeEvent.layout.height);
         }
       }}

--- a/src/components/Post.tsx
+++ b/src/components/Post.tsx
@@ -462,7 +462,7 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
             }
           }}
         >
-          <Icon name="ellipsis-h" size={16} color={colors.neutral.grey1} />
+          <MaterialCommunityIcons name="dots-horizontal" size={20} color={colors.neutral.grey1} />
         </ActionsMenu>
       </View>
       {isChallengePost && (

--- a/src/components/Post.tsx
+++ b/src/components/Post.tsx
@@ -17,6 +17,7 @@ import {
   ActivityIndicator,
 } from "react-native";
 import MaterialCommunityIcons from "react-native-vector-icons/MaterialCommunityIcons";
+import { MenuProvider } from "react-native-popup-menu";
 import { AnimatedSendButton } from "./AnimatedSendButton";
 import CommentPreviewRow from "./CommentPreviewRow";
 import { CommentsModal } from "./Comments";
@@ -660,28 +661,30 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
           visible={showComments}
           onRequestClose={() => setShowComments(false)}
         >
-          <View style={modalOverlayStyle}>
-            <TouchableWithoutFeedback onPress={() => setShowComments(false)}>
-              <View style={modalBackgroundStyle} />
-            </TouchableWithoutFeedback>
+          <MenuProvider skipInstanceCheck>
+            <View style={modalOverlayStyle}>
+              <TouchableWithoutFeedback onPress={() => setShowComments(false)}>
+                <View style={modalBackgroundStyle} />
+              </TouchableWithoutFeedback>
 
-            <KeyboardAvoidingView
-              behavior="padding"
-              style={modalContainerStyle}
-              keyboardVerticalOffset={Platform.OS === "ios" ? 0 : 0}
-            >
-              <CommentsModal
-                initialComments={commentList}
-                onClose={() => setShowComments(false)}
-                loading={commentsLoading}
-                postId={post.id}
-                postUserId={postUser.id}
-                onCommentAdded={handleCommentAdded}
-                addComment={addCommentMutation}
-                isAddingComment={isAddingComment}
-              />
-            </KeyboardAvoidingView>
-          </View>
+              <KeyboardAvoidingView
+                behavior="padding"
+                style={modalContainerStyle}
+                keyboardVerticalOffset={Platform.OS === "ios" ? 0 : 0}
+              >
+                <CommentsModal
+                  initialComments={commentList}
+                  onClose={() => setShowComments(false)}
+                  loading={commentsLoading}
+                  postId={post.id}
+                  postUserId={postUser.id}
+                  onCommentAdded={handleCommentAdded}
+                  addComment={addCommentMutation}
+                  isAddingComment={isAddingComment}
+                />
+              </KeyboardAvoidingView>
+            </View>
+          </MenuProvider>
         </Modal>
 
         <Modal

--- a/src/components/Post.tsx
+++ b/src/components/Post.tsx
@@ -66,6 +66,24 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
   const { user, isAdmin, username: currentUserUsername } = useAuth();
   const cleanupAfterDelete = usePostDeleteCleanup();
   const [showComments, setShowComments] = useState(false);
+  const [containerHeight, setContainerHeight] = useState<number | null>(null);
+  const deleteProgress = useRef(new Animated.Value(1)).current;
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const animateDeletion = useCallback(() => {
+    setIsDeleting(true);
+    Animated.timing(deleteProgress, {
+      toValue: 0,
+      duration: 280,
+      useNativeDriver: false,
+    }).start(() => {
+      cleanupAfterDelete(post);
+      onPostDeleted?.(post);
+      if (isPostPage) {
+        router.back();
+      }
+    });
+  }, [cleanupAfterDelete, deleteProgress, isPostPage, onPostDeleted, post]);
   const [translatedText, setTranslatedText] = useState<string | null>(null);
   const [isTranslating, setIsTranslating] = useState(false);
   const [commentCount, setCommentCount] = useState(post.comments_count || 0);
@@ -428,7 +446,38 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
     );
   }
 
+  const deleteAnimatedStyle = isDeleting
+    ? {
+        opacity: deleteProgress,
+        transform: [
+          {
+            scale: deleteProgress.interpolate({
+              inputRange: [0, 1],
+              outputRange: [0.94, 1],
+            }),
+          },
+        ],
+        height:
+          containerHeight != null
+            ? deleteProgress.interpolate({
+                inputRange: [0, 1],
+                outputRange: [0, containerHeight],
+              })
+            : undefined,
+        overflow: "hidden" as const,
+      }
+    : null;
+
   return (
+    <Animated.View
+      onLayout={(e) => {
+        if (containerHeight == null) {
+          setContainerHeight(e.nativeEvent.layout.height);
+        }
+      }}
+      style={deleteAnimatedStyle}
+      pointerEvents={isDeleting ? "none" : "auto"}
+    >
     <Pressable
       // onPress={handlePostPress}
       style={[
@@ -458,13 +507,7 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
           type="post"
           contentId={post.id}
           contentUserId={post.user_id}
-          onDelete={() => {
-            cleanupAfterDelete(post);
-            onPostDeleted?.(post);
-            if (isPostPage) {
-              router.back();
-            }
-          }}
+          onDelete={animateDeletion}
         >
           <MaterialCommunityIcons name="dots-horizontal" size={20} color={colors.neutral.grey1} />
         </ActionsMenu>
@@ -727,6 +770,7 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
         </Modal>
       </View>
     </Pressable>
+    </Animated.View>
   );
 };
 

--- a/src/components/PostPage.tsx
+++ b/src/components/PostPage.tsx
@@ -16,13 +16,11 @@ import { colors } from '../constants/Colors';
 import { Post as PostType } from '../types';  // todo: rename one of the Post types
 import { Loader } from './Loader';
 import { useLikes } from '../contexts/LikesContext';
-import { useQueryClient } from '@tanstack/react-query';
 const PostPage = () => {
   const params = useLocalSearchParams();
   const idParam = Array.isArray(params.id) ? params.id[0] : params.id;
   const postId = idParam ? parseInt(idParam) : null;
-  const queryClient = useQueryClient();
-  
+
   const { posts, userMap, loading, fetchPost } = useFetchHomeData();
   const { initializePostReactions } = useReactions();
   const { initializePostLikes, likeCounts } = useLikes();
@@ -91,41 +89,6 @@ const PostPage = () => {
 
   const postUser = post ? (userMap?.[post.user_id] ?? fetchedPostUser) : null;
 
-  const handlePostDeleted = (deletedPost: PostType) => {
-    type PaginatedPostsPage = { posts: PostType[]; hasMore: boolean };
-    type PaginatedPostsData = { pages: PaginatedPostsPage[]; pageParams: number[] };
-
-    queryClient.setQueriesData<PaginatedPostsData>({ queryKey: ["home-posts"] }, (oldData) => {
-      if (!oldData) return oldData;
-      return {
-        ...oldData,
-        pages: oldData.pages.map((page) => ({
-          ...page,
-          posts: page.posts.filter((pagePost) => pagePost.id !== deletedPost.id),
-        })),
-      };
-    });
-
-    queryClient.setQueriesData<PaginatedPostsData>({ queryKey: ["challenge-posts"] }, (oldData) => {
-      if (!oldData) return oldData;
-      return {
-        ...oldData,
-        pages: oldData.pages.map((page) => ({
-          ...page,
-          posts: page.posts.filter((pagePost) => pagePost.id !== deletedPost.id),
-        })),
-      };
-    });
-
-    if (deletedPost.challenge_id) {
-      queryClient.invalidateQueries({ queryKey: ["challenge-completion", deletedPost.challenge_id] });
-    }
-
-    if (deletedPost.quest_id) {
-      queryClient.invalidateQueries({ queryKey: ["quest-completion", deletedPost.quest_id] });
-    }
-  };
-
   // avoid flashing "post not found" while we're still resolving data from a notification deep-link
   const isResolvingPost = !!postId && (!post || !postUser);
 
@@ -171,7 +134,6 @@ const PostPage = () => {
           postUser={postUser}
           setPostCounts={() => {}}
           isPostPage={true}
-          onPostDeleted={handlePostDeleted}
         />
       </ScrollView>
     </KeyboardAvoidingView>

--- a/src/components/ProfilePage.tsx
+++ b/src/components/ProfilePage.tsx
@@ -7,12 +7,12 @@ import {
   StyleSheet,
   ScrollView,
   TouchableOpacity,
-  Alert,
   Modal,
   RefreshControl,
   TextInput,
   Linking,
 } from "react-native";
+import { AppAlert } from './AppAlert';
 import UserProgress from "./UserProgress";
 import CommentPreviewRow from "./CommentPreviewRow";
 import Post from "./Post";
@@ -41,7 +41,6 @@ import { BadgePreviewSection } from "./Badges/BadgePreviewSection";
 type ProfilePageProps = {
   userId?: string;
 };
-
 
 export const ProfilePage: React.FC<ProfilePageProps> = ({ userId }) => {
   const { user, signOut } = useAuth();
@@ -100,7 +99,7 @@ export const ProfilePage: React.FC<ProfilePageProps> = ({ userId }) => {
   const handleUpdateProfilePicture = async () => {
     try {
       if (!user?.id) {
-        Alert.alert(t("Error"), t("User not authenticated"));
+        AppAlert.show(t("Error"), t("User not authenticated"));
         return;
       }
 
@@ -130,7 +129,7 @@ export const ProfilePage: React.FC<ProfilePageProps> = ({ userId }) => {
           [USER_PROPERTIES.HAS_PROFILE_PICTURE]: true,
         });
       } else if (result.error) {
-        Alert.alert("Error", result.error);
+        AppAlert.show("Error", result.error);
       }
     } finally {
       setImageUploading(false);
@@ -142,14 +141,14 @@ export const ProfilePage: React.FC<ProfilePageProps> = ({ userId }) => {
       if (editedInstagram && editedInstagram !== userProfile?.instagram) {
         const instagramRegex = /^[a-zA-Z0-9._]+$/;
         if (!instagramRegex.test(editedInstagram)) {
-          Alert.alert(t("Error"), t("Instagram usernames can only use letters, numbers, underscores and periods."));
+          AppAlert.show(t("Error"), t("Instagram usernames can only use letters, numbers, underscores and periods."));
           return;
         }
 
         try {
           const isValid = await isInstagramUsernameValidProfile(editedInstagram);
           if (!isValid) {
-            Alert.alert(t("Error"), t("Instagram profile not found. Check your username"));
+            AppAlert.show(t("Error"), t("Instagram profile not found. Check your username"));
             return;
           }
         } catch (err) {
@@ -187,10 +186,10 @@ export const ProfilePage: React.FC<ProfilePageProps> = ({ userId }) => {
           });
         }
       } else if (result.error) {
-        Alert.alert("Error", result.error);
+        AppAlert.show("Error", result.error);
       }
     } catch (error) {
-      Alert.alert("Error", (error as Error).message);
+      AppAlert.show("Error", (error as Error).message);
     }
   };
 
@@ -215,10 +214,10 @@ export const ProfilePage: React.FC<ProfilePageProps> = ({ userId }) => {
         captureEvent(PROFILE_EVENTS.ACCOUNT_DELETED);
         await signOut();
       } else if (result.error) {
-        Alert.alert("Error", result.error || t("Failed to Delete account"));
+        AppAlert.show("Error", result.error || t("Failed to Delete account"));
       }
     } catch (error) {
-      Alert.alert("Error", (error as Error).message);
+      AppAlert.show("Error", (error as Error).message);
     }
   };
 
@@ -291,7 +290,6 @@ export const ProfilePage: React.FC<ProfilePageProps> = ({ userId }) => {
   if (progressLoading || profileLoading || !userProfile) {
     return <ProfileSkeleton />;
   }
-
 
   if (error || profileError) {
     return (
@@ -533,7 +531,7 @@ export const ProfilePage: React.FC<ProfilePageProps> = ({ userId }) => {
               style={styles.commentCard}
               onPress={() => {
                 if (!item.comment.post) {
-                  Alert.alert(t("Post not found"), t("This post may have been deleted."));
+                  AppAlert.show(t("Post not found"), t("This post may have been deleted."));
                   return;
                 }
                 router.push(`/post/${item.comment.post_id}`);

--- a/src/components/ProfilePage.tsx
+++ b/src/components/ProfilePage.tsx
@@ -203,35 +203,8 @@ export const ProfilePage: React.FC<ProfilePageProps> = ({ userId }) => {
   const handlePostDeleted = useCallback(
     (post: PostType) => {
       removePost(post.id);
-
-      type FeedPage = { posts: PostType[]; hasMore: boolean };
-      type FeedData = { pages: FeedPage[]; pageParams: number[] };
-      const stripPost = (oldData: FeedData | undefined) => {
-        if (!oldData) return oldData;
-        return {
-          ...oldData,
-          pages: oldData.pages.map((page) => ({
-            ...page,
-            posts: page.posts.filter((p) => p.id !== post.id),
-          })),
-        };
-      };
-      queryClient.setQueriesData<FeedData>({ queryKey: ["home-posts"] }, stripPost);
-      if (post.challenge_id) {
-        queryClient.setQueriesData<FeedData>(
-          { queryKey: ["challenge-posts", post.challenge_id] },
-          stripPost
-        );
-      }
-
-      if (post.challenge_id) {
-        queryClient.invalidateQueries({ queryKey: ["challenge-completion", post.challenge_id] });
-      }
-      if (post.quest_id) {
-        queryClient.invalidateQueries({ queryKey: ["quest-completion", post.quest_id] });
-      }
     },
-    [removePost, queryClient]
+    [removePost]
   );
 
   const handleSignOut = async () => {

--- a/src/components/ProfilePage.tsx
+++ b/src/components/ProfilePage.tsx
@@ -16,6 +16,7 @@ import { AppAlert } from './AppAlert';
 import UserProgress from "./UserProgress";
 import CommentPreviewRow from "./CommentPreviewRow";
 import Post from "./Post";
+import { Post as PostType } from "../types";
 import useUserProgress from "../hooks/useUserProgress";
 import { useProfileActivity } from "../hooks/useProfileActivity";
 import { router } from "expo-router";
@@ -59,6 +60,7 @@ export const ProfilePage: React.FC<ProfilePageProps> = ({ userId }) => {
     hasMore: hasMoreActivity,
     fetchNextPage,
     refresh: refreshActivity,
+    removePost,
   } = useProfileActivity(targetUserId);
   const [activityFilter, setActivityFilter] = useState<"all" | "post" | "comment">("all");
   const [refreshing, setRefreshing] = useState(false);
@@ -197,6 +199,40 @@ export const ProfilePage: React.FC<ProfilePageProps> = ({ userId }) => {
     if (activityLoading || !hasMoreActivity) return;
     fetchNextPage();
   };
+
+  const handlePostDeleted = useCallback(
+    (post: PostType) => {
+      removePost(post.id);
+
+      type FeedPage = { posts: PostType[]; hasMore: boolean };
+      type FeedData = { pages: FeedPage[]; pageParams: number[] };
+      const stripPost = (oldData: FeedData | undefined) => {
+        if (!oldData) return oldData;
+        return {
+          ...oldData,
+          pages: oldData.pages.map((page) => ({
+            ...page,
+            posts: page.posts.filter((p) => p.id !== post.id),
+          })),
+        };
+      };
+      queryClient.setQueriesData<FeedData>({ queryKey: ["home-posts"] }, stripPost);
+      if (post.challenge_id) {
+        queryClient.setQueriesData<FeedData>(
+          { queryKey: ["challenge-posts", post.challenge_id] },
+          stripPost
+        );
+      }
+
+      if (post.challenge_id) {
+        queryClient.invalidateQueries({ queryKey: ["challenge-completion", post.challenge_id] });
+      }
+      if (post.quest_id) {
+        queryClient.invalidateQueries({ queryKey: ["quest-completion", post.quest_id] });
+      }
+    },
+    [removePost, queryClient]
+  );
 
   const handleSignOut = async () => {
     try {
@@ -520,7 +556,7 @@ export const ProfilePage: React.FC<ProfilePageProps> = ({ userId }) => {
                 post={item.post}
                 postUser={userProfile}
                 setPostCounts={() => { }}
-                onPostDeleted={() => {}}
+                onPostDeleted={handlePostDeleted}
               />
             );
           }

--- a/src/components/ShareChallenge.tsx
+++ b/src/components/ShareChallenge.tsx
@@ -48,6 +48,7 @@ const ShareChallenge: React.FC<ShareChallengeProps> = ({
   const bodyProgress = useRef(new Animated.Value(0)).current;
   const [burstSession, setBurstSession] = React.useState(0);
   const [contentMounted, setContentMounted] = React.useState(false);
+  const openedCountRef = useRef(0);
 
   React.useEffect(() => {
     const loadProfileImage = async () => {
@@ -86,6 +87,7 @@ const ShareChallenge: React.FC<ShareChallengeProps> = ({
       return () => clearTimeout(unmountTimer);
     }
 
+    openedCountRef.current = completionCount;
     setContentMounted(true);
     setBurstSession(s => s + 1);
     countAnim.setValue(0);
@@ -94,7 +96,7 @@ const ShareChallenge: React.FC<ShareChallengeProps> = ({
 
     const t1 = setTimeout(() => confettiRef.current?.start(), 3300);
 
-    const target = completionCount;
+    const target = openedCountRef.current;
     const listener = countAnim.addListener(({ value }) => {
       setDisplayCount(Math.round(value));
     });
@@ -118,7 +120,8 @@ const ShareChallenge: React.FC<ShareChallengeProps> = ({
       clearTimeout(t1);
       countAnim.removeListener(listener);
     };
-  }, [isVisible, completionCount, countAnim, bodyProgress]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isVisible]);
 
   const handleShare = async () => {
     try {
@@ -250,7 +253,7 @@ const ShareChallenge: React.FC<ShareChallengeProps> = ({
 
               <Text style={styles.inspireText}>
                 <MaterialCommunityIcons name="shimmer" size={14} color={colors.light.accent} />
-                {' '}{t('Inspire your friend to be the (count)th!', { count: completionCount + 1 })}
+                {' '}{t('Inspire your friend to be the (count)th!', { count: displayCount + 1 })}
               </Text>
             </View>
 

--- a/src/components/ShareChallenge.tsx
+++ b/src/components/ShareChallenge.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect, useMemo } from 'react';
-import { View, StyleSheet, TouchableOpacity, Share, Modal, Image, ActivityIndicator } from 'react-native';
+import { View, StyleSheet, TouchableOpacity, Share, Modal, Image, ActivityIndicator, Animated, Easing } from 'react-native';
 import { Text } from './StyledText';
 import { colors } from '../constants/Colors';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
@@ -15,6 +15,7 @@ import InstagramStoryCard from './InstagramStoryCard';
 import { captureRef } from 'react-native-view-shot';
 import { instagramShareService } from '../services/instagramShareService';
 import { Image as ExpoImage } from 'expo-image';
+import CompletionBurst from './CompletionBurst';
 
 interface ShareChallengeProps {
   isVisible: boolean;
@@ -42,6 +43,11 @@ const ShareChallenge: React.FC<ShareChallengeProps> = ({
   const [isSharing, setIsSharing] = React.useState(false);
   const [profileImageUrl, setProfileImageUrl] = React.useState<string | null>(null);
   const { completionCount } = useActiveChallenge();
+  const countAnim = useRef(new Animated.Value(0)).current;
+  const [displayCount, setDisplayCount] = React.useState(0);
+  const bodyProgress = useRef(new Animated.Value(0)).current;
+  const [burstSession, setBurstSession] = React.useState(0);
+  const [contentMounted, setContentMounted] = React.useState(false);
 
   React.useEffect(() => {
     const loadProfileImage = async () => {
@@ -70,14 +76,49 @@ const ShareChallenge: React.FC<ShareChallengeProps> = ({
   }, [isVisible]);
 
   useEffect(() => {
-    if (isVisible) {
-      setTimeout(() => {
-        if (confettiRef.current) {
-          confettiRef.current.start();
-        }
-      }, 100);
+    if (!isVisible) {
+      const unmountTimer = setTimeout(() => {
+        setContentMounted(false);
+        countAnim.setValue(0);
+        bodyProgress.setValue(0);
+        setDisplayCount(0);
+      }, 320);
+      return () => clearTimeout(unmountTimer);
     }
-  }, [isVisible]);
+
+    setContentMounted(true);
+    setBurstSession(s => s + 1);
+    countAnim.setValue(0);
+    bodyProgress.setValue(0);
+    setDisplayCount(0);
+
+    const t1 = setTimeout(() => confettiRef.current?.start(), 3300);
+
+    const target = completionCount;
+    const listener = countAnim.addListener(({ value }) => {
+      setDisplayCount(Math.round(value));
+    });
+    Animated.timing(countAnim, {
+      toValue: target,
+      duration: 1100,
+      delay: 1650,
+      easing: Easing.out(Easing.cubic),
+      useNativeDriver: false,
+    }).start();
+
+    Animated.timing(bodyProgress, {
+      toValue: 1,
+      duration: 520,
+      delay: 1700,
+      easing: Easing.out(Easing.cubic),
+      useNativeDriver: true,
+    }).start();
+
+    return () => {
+      clearTimeout(t1);
+      countAnim.removeListener(listener);
+    };
+  }, [isVisible, completionCount, countAnim, bodyProgress]);
 
   const handleShare = async () => {
     try {
@@ -160,17 +201,6 @@ const ShareChallenge: React.FC<ShareChallengeProps> = ({
       onRequestClose={onClose}
     >
       <View style={styles.modalOverlay}>
-        <ConfettiCannon
-          ref={confettiRef}
-          count={200}
-          origin={{x: -10, y: 0}}
-          fallSpeed={3000}
-          explosionSpeed={1000}
-          fadeOut={true}
-          colors={['#FFD700', '#FFA500', '#FF69B4', '#87CEEB', '#98FB98']}
-          autoStartDelay={0}
-        />
-
         {/* Hidden Instagram Story Card for capture */}
         <InstagramStoryCard
           ref={storyCardRef}
@@ -184,66 +214,95 @@ const ShareChallenge: React.FC<ShareChallengeProps> = ({
 
         <View style={styles.modalContent}>
           <View style={styles.celebrationContainer}>
-            <Text style={styles.title}>{t(celebrationText)}</Text>
+            {contentMounted && (
+              <CompletionBurst key={burstSession} title={t(celebrationText)} />
+            )}
           </View>
 
-          {mediaPreview && (
-            <Image
-              source={{ uri: mediaPreview }}
-              style={styles.mediaPreview}
-              resizeMode="cover"
-            />
-          )}
-          <View style={styles.socialProofContainer}>
-            <Text style={styles.socialProofText}>
-              <Text style={styles.highlight}>
-                {t('(count) people', { count: completionCount })}
-              </Text>
-              {' '}
-              {t('have stepped out of their comfort zone this week.')}
-            </Text>
-
-            <Text style={styles.inspireText}>
-              <MaterialCommunityIcons name="shimmer" size={14} color={colors.light.accent} />
-              {' '}{t('Inspire your friend to be the (count)th!', { count: completionCount + 1 })}
-            </Text>
-          </View>
-
-          <View style={styles.shareButtons}>
-            <TouchableOpacity
-              style={styles.instagramButton}
-              onPress={handleInstagramShare}
-              disabled={isSharing}
-            >
-              {isSharing ? (
-                <ActivityIndicator size="small" color="white" />
-              ) : (
-                <MaterialCommunityIcons name="instagram" size={20} color="white" />
-              )}
-              <Text style={styles.buttonText}>
-                {isSharing ? t('Sharing...') : t('Share to Instagram Story')}
-              </Text>
-            </TouchableOpacity>
-
-            <TouchableOpacity
-              style={styles.friendButton}
-              onPress={handleShare}
-            >
-              <MaterialCommunityIcons name="send" size={18} color="white" style={{ transform: [{ rotate: '-30deg' }] }} />
-              <Text style={styles.friendButtonText}>{t('Share with a friend')}</Text>
-            </TouchableOpacity>
-          </View>
-
-          <TouchableOpacity
-            onPress={() => {
-              captureEvent(CHALLENGE_EVENTS.SHARE_SKIPPED, {
-                challenge_id: challengeId,
-              });
-              onClose();
+          <Animated.View
+            style={{
+              opacity: bodyProgress,
+              transform: [
+                {
+                  translateY: bodyProgress.interpolate({
+                    inputRange: [0, 1],
+                    outputRange: [20, 0],
+                  }),
+                },
+              ],
             }}
           >
-            <Text style={styles.skipText}>{t('Skip')}</Text>
-          </TouchableOpacity>
+            {mediaPreview && (
+              <Image
+                source={{ uri: mediaPreview }}
+                style={styles.mediaPreview}
+                resizeMode="cover"
+              />
+            )}
+            <View style={styles.socialProofContainer}>
+              <Text style={styles.socialProofText}>
+                <Text style={styles.highlight}>
+                  {t('(count) people', { count: displayCount })}
+                </Text>
+                {' '}
+                {t('have stepped out of their comfort zone this week.')}
+              </Text>
+
+              <Text style={styles.inspireText}>
+                <MaterialCommunityIcons name="shimmer" size={14} color={colors.light.accent} />
+                {' '}{t('Inspire your friend to be the (count)th!', { count: completionCount + 1 })}
+              </Text>
+            </View>
+
+            <View style={styles.shareButtons}>
+              <TouchableOpacity
+                style={styles.instagramButton}
+                onPress={handleInstagramShare}
+                disabled={isSharing}
+              >
+                {isSharing ? (
+                  <ActivityIndicator size="small" color="white" />
+                ) : (
+                  <MaterialCommunityIcons name="instagram" size={20} color="white" />
+                )}
+                <Text style={styles.buttonText}>
+                  {isSharing ? t('Sharing...') : t('Share to Instagram Story')}
+                </Text>
+              </TouchableOpacity>
+
+              <TouchableOpacity
+                style={styles.friendButton}
+                onPress={handleShare}
+              >
+                <MaterialCommunityIcons name="send" size={18} color="white" style={{ transform: [{ rotate: '-30deg' }] }} />
+                <Text style={styles.friendButtonText}>{t('Share with a friend')}</Text>
+              </TouchableOpacity>
+            </View>
+
+            <TouchableOpacity
+              onPress={() => {
+                captureEvent(CHALLENGE_EVENTS.SHARE_SKIPPED, {
+                  challenge_id: challengeId,
+                });
+                onClose();
+              }}
+            >
+              <Text style={styles.skipText}>{t('Skip')}</Text>
+            </TouchableOpacity>
+          </Animated.View>
+        </View>
+
+        <View pointerEvents="none" style={StyleSheet.absoluteFill}>
+          <ConfettiCannon
+            ref={confettiRef}
+            count={90}
+            origin={{x: -10, y: -20}}
+            fallSpeed={2800}
+            explosionSpeed={600}
+            fadeOut={true}
+            colors={['#FFE27A', '#FFB347', '#FF6B3D', '#FFD166', '#F5F2ED']}
+            autoStart={false}
+          />
         </View>
       </View>
     </Modal>
@@ -325,6 +384,7 @@ const styles = StyleSheet.create({
     backgroundColor: colors.light.background,
     borderRadius: 24,
     maxWidth: 400,
+    overflow: 'visible',
     paddingVertical: 24,
     paddingHorizontal: 26,
     width: '90%',
@@ -354,13 +414,6 @@ const styles = StyleSheet.create({
     fontSize: 16,
     lineHeight: 24,
     marginBottom: 12,
-    textAlign: 'center',
-  },
-  title: {
-    color: colors.light.text,
-    fontSize: 26,
-    fontWeight: 'bold',
-    marginBottom: 4,
     textAlign: 'center',
   },
 });

--- a/src/components/SideQuestPath.tsx
+++ b/src/components/SideQuestPath.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { Alert, Animated, ScrollView, StyleSheet, TouchableOpacity, View } from "react-native";
+import { Animated, ScrollView, StyleSheet, TouchableOpacity, View } from "react-native";
+import { AppAlert } from './AppAlert';
 import MaterialCommunityIcons from "react-native-vector-icons/MaterialCommunityIcons";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Text } from "./StyledText";
@@ -370,7 +371,7 @@ export const SideQuestPath: React.FC = () => {
         step_index: currentQuestionIndex,
         message: (error as Error).message,
       });
-      Alert.alert(t("Error"), (error as Error).message);
+      AppAlert.show(t("Error"), (error as Error).message);
     }
   };
 
@@ -412,7 +413,7 @@ export const SideQuestPath: React.FC = () => {
         setIsDrawingQuest(false);
       }
     } catch (error) {
-      Alert.alert(t("Error"), (error as Error).message);
+      AppAlert.show(t("Error"), (error as Error).message);
       setIsRevealing(false);
       setRevealedQuest(null);
       setIsDrawingQuest(false);

--- a/src/hooks/useMediaUpload.ts
+++ b/src/hooks/useMediaUpload.ts
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
-import { Alert, Linking, Platform } from 'react-native';
+import { Linking, Platform } from 'react-native';
+import { AppAlert } from '../components/AppAlert';
 import { useUploadProgress } from '../contexts/UploadProgressContext';
 import { createProgressManager } from '../utils/progressManager';
 import { selectMediaForPreview, MediaSelectionResult } from '../utils/handleMediaUpload';
@@ -55,7 +56,7 @@ export const useMediaUpload = (options: UseMediaUploadOptions = {}) => {
       
       // Check if it's a permissions error
       if (error?.message?.includes('permissions not granted')) {
-        Alert.alert(
+        AppAlert.show(
           t('Photo Access Required'),
           t('Please enable photo library access in Settings to share photos and videos.'),
           [

--- a/src/hooks/usePostDeleteCleanup.ts
+++ b/src/hooks/usePostDeleteCleanup.ts
@@ -1,0 +1,36 @@
+import { useCallback } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { Post as PostType } from "../types";
+
+type FeedPage = { posts: PostType[]; hasMore: boolean };
+type FeedData = { pages: FeedPage[]; pageParams: number[] };
+
+export const usePostDeleteCleanup = () => {
+  const queryClient = useQueryClient();
+
+  return useCallback(
+    (post: PostType) => {
+      const stripPost = (oldData: FeedData | undefined) => {
+        if (!oldData) return oldData;
+        return {
+          ...oldData,
+          pages: oldData.pages.map((page) => ({
+            ...page,
+            posts: page.posts.filter((p) => p.id !== post.id),
+          })),
+        };
+      };
+
+      queryClient.setQueriesData<FeedData>({ queryKey: ["home-posts"] }, stripPost);
+      queryClient.setQueriesData<FeedData>({ queryKey: ["challenge-posts"] }, stripPost);
+
+      if (post.challenge_id) {
+        queryClient.invalidateQueries({ queryKey: ["challenge-completion", post.challenge_id] });
+      }
+      if (post.quest_id) {
+        queryClient.invalidateQueries({ queryKey: ["quest-completion", post.quest_id] });
+      }
+    },
+    [queryClient]
+  );
+};

--- a/src/hooks/useProfileActivity.ts
+++ b/src/hooks/useProfileActivity.ts
@@ -128,11 +128,18 @@ export const useProfileActivity = (targetUserId: string) => {
     fetchNextPage(true);
   }, [targetUserId]);
 
+  const removePost = useCallback((postId: number) => {
+    setItems((prev) =>
+      prev.filter((item) => !(item.type === "post" && item.post.id === postId))
+    );
+  }, []);
+
   return {
     activityItems: items,
     loading,
     hasMore,
     fetchNextPage,
     refresh: () => fetchNextPage(true),
+    removePost,
   };
 };

--- a/src/services/profileService.ts
+++ b/src/services/profileService.ts
@@ -1,6 +1,7 @@
+import { AppAlert } from '../components/AppAlert';
 import { supabase } from "../lib/supabase";
 import { selectMediaForPreview, uploadMediaInBackground } from "../utils/handleMediaUpload";
-import { Alert } from "react-native";
+
 import { User, UserProfile } from "../models/User";
 import { imageService } from "./imageService";
 
@@ -151,7 +152,7 @@ export const profileService = {
   ): Promise<{ success: boolean; error?: string }> {
     return new Promise((resolve) => {
       // First confirmation
-      Alert.alert(
+      AppAlert.show(
         t("Delete account"),
         t("Are you sure you want to proceed? This will permanently delete your account."),
         [
@@ -165,7 +166,7 @@ export const profileService = {
             style: "destructive",
             onPress: () => {
               // Second confirmation
-              Alert.alert(
+              AppAlert.show(
                 t("Final Warning"),
                 t(
                   "This action cannot be undone. All your data will be permanently deleted. Are you absolutely sure?"


### PR DESCRIPTION
## Summary

### Completion burst animation (`ShareChallenge`)
- Replaces confetti-only completion with a choreographed sequence: golden trophy spirals along a screen-sized arc, lands center, then rays, shock rings, and sparkles burst out
- Confetti fires at the landing peak after the JS-heavy spiral/count animations finish, so it no longer stutters
- Trail rebuilt from an SVG-masked tapered polygon to ~110 native-driven dots sampled at uniform arc length along the spiral. Each dot's opacity is derived from the trophy's own progress value via `Animated.multiply` + native-driven interpolate — the trail is mathematically locked to the trophy, runs entirely on the UI thread, and each dot fades out shortly after the trophy passes it for a comet-tail look
- Modal teardown delayed past the fade-out so content doesn't strand mid-exit when Skip is pressed

### Post deletion polish
- New `usePostDeleteCleanup` hook centralizes query-cache stripping and challenge/quest completion invalidation, called from `Post` itself (was duplicated across home, profile, challenge, and post pages)
- Deleted post animates out (fade + scale + height collapse, 280ms) before cleanup so the row eases out instead of vanishing
- Profile posts vanish immediately on delete; challenge completion cache invalidated alongside

### Menus + alerts
- Branded `AppAlert` modal replaces system alerts
- Post/comment menu icon modernized
- Post actions menu now opens above the trigger
- Fixed comments-menu placement bug: nested `MenuProvider` inside the bottom-anchored modal sheet was ~25% of screen tall, so popup placement math measured the trigger in screen coords but positioned within the smaller container — hoisting `MenuProvider` fixes the offset

## Test plan
- [ ] Complete a challenge → trophy spirals, trail reads as a continuous comet tail (no gaps, no white holes near center), confetti fires cleanly, Skip exits without stranded content
- [ ] Delete a post from home, profile, challenge page, and post detail — confirm animated collapse and that challenge/quest completion state updates immediately
- [ ] Trigger an `AppAlert` and confirm styling
- [ ] Open the post actions menu (renders above the trigger) and the comments menu (correctly placed at the icon, not offset by the modal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)