### PR TITLE
add past side quest history

### DIFF
--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -75,6 +75,7 @@ function RootLayoutNav() {
   const isDetailPage = pathname.includes('/post/') ||
     pathname.includes('/profile/') ||
     pathname.includes('/challenge/') ||
+    pathname.includes('/quest/') ||
     pathname.includes('/esplora/piece/') ||
     pathname.includes('/esplora/category/') ||
     pathname === '/esplora/saved' ||

--- a/src/app/quest/[id].tsx
+++ b/src/app/quest/[id].tsx
@@ -1,0 +1,20 @@
+import { Stack } from "expo-router";
+import { SafeAreaView, StyleSheet } from "react-native";
+import { QuestPage } from "../../components/QuestPage";
+
+export default function QuestPageWrapper() {
+  return (
+    <>
+      <Stack.Screen options={{ headerShown: false }} />
+      <SafeAreaView style={styles.container}>
+        <QuestPage />
+      </SafeAreaView>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});

--- a/src/components/ChallengePreviewCard.tsx
+++ b/src/components/ChallengePreviewCard.tsx
@@ -16,6 +16,99 @@ type ChallengePreviewCardProps = {
   onPress: () => void;
 };
 
+type QuestPreviewCardProps = {
+  title: string;
+  description: string;
+  footerLabel?: string | null;
+  onPress: () => void;
+};
+
+type SharedPreviewCardProps = {
+  title: string;
+  description: string;
+  footerLabel?: string | null;
+  onPress: () => void;
+  accentVariant: "challenge" | "quest";
+  badge: React.ReactNode;
+  imagePath?: string | null;
+};
+
+function SharedPreviewCard({
+  title,
+  description,
+  footerLabel,
+  onPress,
+  accentVariant,
+  badge,
+  imagePath,
+}: SharedPreviewCardProps) {
+  const variantStyles = accentVariant === "quest" ? questStyles : challengeStyles;
+  const descriptionLines = footerLabel ? 2 : 3;
+
+  return (
+    <TouchableOpacity
+      style={[styles.card, variantStyles.card]}
+      onPress={onPress}
+      activeOpacity={0.9}
+      accessibilityRole="button"
+    >
+      {accentVariant === "challenge" && (
+        <>
+          <View pointerEvents="none" style={[styles.glow, variantStyles.glow]} />
+          <View pointerEvents="none" style={[styles.orbitLarge, variantStyles.orbitLarge]} />
+          <View pointerEvents="none" style={[styles.orbitSmall, variantStyles.orbitSmall]} />
+          <View pointerEvents="none" style={[styles.ribbon, variantStyles.ribbon]} />
+        </>
+      )}
+      {accentVariant === "quest" && (
+        <>
+          <View pointerEvents="none" style={[styles.glow, variantStyles.glow]} />
+          <View pointerEvents="none" style={[styles.orbitLarge, variantStyles.orbitLarge]} />
+          <View pointerEvents="none" style={[styles.orbitSmall, variantStyles.orbitSmall]} />
+          <View pointerEvents="none" style={[styles.ribbon, variantStyles.ribbon]} />
+        </>
+      )}
+
+      {imagePath ? (
+        <Image
+          source={{ uri: imageService.getChallengeImageUrlSync(imagePath, "small") }}
+          style={styles.image}
+        />
+      ) : (
+        <View style={[styles.image, styles.imageFallback, variantStyles.imageFallback]}>
+          {accentVariant === "quest" && (
+            <MaterialIcons name="explore" size={30} color={colors.sideQuest.text} />
+          )}
+        </View>
+      )}
+
+      <View style={styles.content}>
+        <View style={styles.titleRow}>
+          <Text style={[styles.title, variantStyles.title]} numberOfLines={2}>
+            {title}
+          </Text>
+          {badge}
+        </View>
+        <Text style={styles.description} numberOfLines={descriptionLines}>
+          {description}
+        </Text>
+        {!!footerLabel && (
+          <View style={styles.footerRow}>
+            <Text style={[styles.footerLabel, variantStyles.footerLabel]}>{footerLabel}</Text>
+          </View>
+        )}
+      </View>
+
+      <MaterialIcons
+        name="chevron-right"
+        size={22}
+        color={accentVariant === "quest" ? colors.sideQuest.text : colors.light.primary}
+        style={styles.chevron}
+      />
+    </TouchableOpacity>
+  );
+}
+
 export const ChallengePreviewCard: React.FC<ChallengePreviewCardProps> = ({
   title,
   description,
@@ -29,70 +122,67 @@ export const ChallengePreviewCard: React.FC<ChallengePreviewCardProps> = ({
     daysRemaining === null || daysRemaining === undefined
       ? null
       : t(daysRemaining === 1 ? "Ends in 1 day" : "Ends in (days) days", { days: daysRemaining });
-  const descriptionLines = footerLabel ? 2 : 3;
 
   return (
-    <TouchableOpacity
-      style={styles.card}
+    <SharedPreviewCard
+      title={title}
+      description={description}
+      footerLabel={footerLabel}
       onPress={onPress}
-      activeOpacity={0.9}
-      accessibilityRole="button"
-    >
-      <View pointerEvents="none" style={styles.glow} />
-      <View pointerEvents="none" style={styles.orbitLarge} />
-      <View pointerEvents="none" style={styles.orbitSmall} />
-      <View pointerEvents="none" style={styles.ribbon} />
-
-      {imagePath ? (
-        <Image
-          source={{ uri: imageService.getChallengeImageUrlSync(imagePath, "small") }}
-          style={styles.image}
-        />
-      ) : (
-        <View style={[styles.image, styles.imageFallback]} />
-      )}
-      <View style={styles.content}>
-        <View style={styles.titleRow}>
-          <Text style={styles.title} numberOfLines={2}>
-            {title}
+      accentVariant="challenge"
+      imagePath={imagePath}
+      badge={
+        <View
+          style={[
+            styles.badge,
+            {
+              backgroundColor: getChallengeDifficultyColor(difficulty),
+            },
+          ]}
+        >
+          <Text style={styles.badgeText}>
+            {t(difficulty.charAt(0).toUpperCase() + difficulty.slice(1))}
           </Text>
-          <View
-            style={[
-              styles.difficultyBadge,
-              { backgroundColor: getChallengeDifficultyColor(difficulty) },
-            ]}
-          >
-            <Text style={styles.difficultyText}>
-              {t(difficulty.charAt(0).toUpperCase() + difficulty.slice(1))}
-            </Text>
-          </View>
         </View>
-        <Text style={styles.description} numberOfLines={descriptionLines}>
-          {description}
-        </Text>
-        {!!footerLabel && (
-          <View style={styles.footerRow}>
-            <Text style={styles.footerLabel}>{footerLabel}</Text>
-          </View>
-        )}
-      </View>
-      <MaterialIcons
-        name="chevron-right"
-        size={22}
-        color={colors.light.lightText}
-        style={styles.chevron}
-      />
-    </TouchableOpacity>
+      }
+    />
+  );
+};
+
+export const QuestPreviewCard: React.FC<QuestPreviewCardProps> = ({
+  title,
+  description,
+  footerLabel,
+  onPress,
+}) => {
+  return (
+    <SharedPreviewCard
+      title={title}
+      description={description}
+      footerLabel={footerLabel}
+      onPress={onPress}
+      accentVariant="quest"
+      badge={null}
+    />
   );
 };
 
 const styles = StyleSheet.create({
+  badge: {
+    borderRadius: 10,
+    marginTop: 1,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+  },
+  badgeText: {
+    color: colors.light.text,
+    fontSize: 11,
+    fontWeight: "600",
+  },
   card: {
     alignItems: "center",
-    backgroundColor: "#EEEFFC",
-    borderColor: "#B7BCE0",
-    borderWidth: 1,
     borderRadius: 16,
+    borderWidth: 1,
     flexDirection: "row",
     overflow: "hidden",
     padding: 10,
@@ -100,16 +190,6 @@ const styles = StyleSheet.create({
   },
   chevron: {
     alignSelf: "center",
-    color: colors.light.primary,
-  },
-  image: {
-    backgroundColor: colors.neutral.grey1,
-    borderRadius: 10,
-    height: 72,
-    width: 72,
-  },
-  imageFallback: {
-    backgroundColor: colors.neutral.grey1,
   },
   content: {
     flex: 1,
@@ -123,31 +203,7 @@ const styles = StyleSheet.create({
     lineHeight: 16,
     marginTop: 4,
   },
-  titleRow: {
-    alignItems: "flex-start",
-    flexDirection: "row",
-    gap: 8,
-  },
-  title: {
-    color: colors.light.primary,
-    flex: 1,
-    fontSize: 15,
-    fontWeight: "700",
-    lineHeight: 19,
-  },
-  difficultyBadge: {
-    borderRadius: 10,
-    paddingHorizontal: 8,
-    paddingVertical: 2,
-    marginTop: 1,
-  },
-  difficultyText: {
-    color: colors.light.text,
-    fontSize: 11,
-    fontWeight: "600",
-  },
   footerLabel: {
-    color: colors.light.primary,
     flexShrink: 1,
     fontSize: 11,
     fontWeight: "600",
@@ -160,7 +216,6 @@ const styles = StyleSheet.create({
     marginTop: 8,
   },
   glow: {
-    backgroundColor: "rgba(103, 109, 160, 0.12)",
     borderRadius: 999,
     height: 90,
     position: "absolute",
@@ -168,8 +223,18 @@ const styles = StyleSheet.create({
     top: -32,
     width: 90,
   },
+  image: {
+    backgroundColor: colors.neutral.grey1,
+    borderRadius: 10,
+    height: 72,
+    width: 72,
+  },
+  imageFallback: {
+    alignItems: "center",
+    overflow: "hidden",
+    justifyContent: "center",
+  },
   orbitLarge: {
-    borderColor: "rgba(103, 109, 160, 0.14)",
     borderRadius: 999,
     borderWidth: 1,
     height: 54,
@@ -180,7 +245,6 @@ const styles = StyleSheet.create({
     width: 54,
   },
   orbitSmall: {
-    borderColor: "rgba(103, 109, 160, 0.10)",
     borderRadius: 999,
     borderWidth: 1,
     height: 30,
@@ -191,7 +255,6 @@ const styles = StyleSheet.create({
     width: 30,
   },
   ribbon: {
-    backgroundColor: "rgba(103, 109, 160, 0.11)",
     borderRadius: 999,
     height: 8,
     position: "absolute",
@@ -200,4 +263,81 @@ const styles = StyleSheet.create({
     transform: [{ rotate: "-18deg" }],
     width: 38,
   },
+  title: {
+    flex: 1,
+    fontSize: 15,
+    fontWeight: "700",
+    lineHeight: 19,
+  },
+  titleRow: {
+    alignItems: "flex-start",
+    flexDirection: "row",
+    gap: 8,
+  },
 });
+
+const challengeStyles = {
+  card: {
+    backgroundColor: "#EEEFFC",
+    borderColor: "#B7BCE0",
+  },
+  footerLabel: {
+    color: colors.light.primary,
+  },
+  glow: {
+    backgroundColor: "rgba(103, 109, 160, 0.12)",
+  },
+  imageFallback: {
+    backgroundColor: colors.neutral.grey1,
+  },
+  orbitLarge: {
+    borderColor: "rgba(103, 109, 160, 0.14)",
+  },
+  orbitSmall: {
+    borderColor: "rgba(103, 109, 160, 0.10)",
+  },
+  ribbon: {
+    backgroundColor: "rgba(103, 109, 160, 0.11)",
+  },
+  title: {
+    color: colors.light.primary,
+  },
+};
+
+const questStyles = {
+  badge: {
+    backgroundColor: colors.sideQuest.bg,
+    borderColor: colors.sideQuest.bgBorder,
+    borderWidth: 1,
+  },
+  badgeText: {
+    color: colors.sideQuest.text,
+  },
+  card: {
+    backgroundColor: colors.sideQuest.bg,
+    borderColor: colors.sideQuest.bgBorder,
+  },
+  footerLabel: {
+    color: colors.sideQuest.text,
+  },
+  glow: {
+    backgroundColor: colors.sideQuest.tint,
+  },
+  imageFallback: {
+    backgroundColor: colors.sideQuest.highlightSoft,
+    borderColor: colors.sideQuest.bgBorder,
+    borderWidth: 1,
+  },
+  orbitLarge: {
+    borderColor: "rgba(161, 78, 57, 0.11)",
+  },
+  orbitSmall: {
+    borderColor: "rgba(161, 78, 57, 0.09)",
+  },
+  ribbon: {
+    backgroundColor: colors.sideQuest.fill,
+  },
+  title: {
+    color: colors.sideQuest.textStrong,
+  },
+};

--- a/src/components/CompletionCelebrationModal.tsx
+++ b/src/components/CompletionCelebrationModal.tsx
@@ -101,17 +101,17 @@ const CompletionCelebrationModal: React.FC<CompletionCelebrationModalProps> = ({
       eventIdKey: 'quest_id',
       eventTitleKey: 'quest_title',
       events: SIDE_QUEST_EVENTS,
-      helperCopy: t('completed for today. Share it now before tomorrow brings a new one.'),
-      inspireCopy: t('Pull a friend into today’s adventure.'),
+      helperCopy: t('completed. Share it now.'),
+      inspireCopy: t('Pull a friend into this adventure.'),
       messageBuilder: async () => {
         const shareLink = await appConfigService.getShareLink();
-        return t("I just completed today's side quest on Stepn Out. Come try one too.\n\n(link)", {
+        return t("I just completed a side quest on Stepn Out. Come try one too.\n\n(link)", {
           link: shareLink,
         });
       },
       modalOpenedEvent: SIDE_QUEST_EVENTS.SHARE_MODAL_OPENED,
       storyVariant: 'quest' as const,
-      subtitle: t("Today's side quest"),
+      subtitle: t("This side quest"),
     },
   }[variant];
 

--- a/src/components/CompletionPostComposer.tsx
+++ b/src/components/CompletionPostComposer.tsx
@@ -78,7 +78,7 @@ export const CompletionPostComposer: React.FC<CompletionPostComposerProps> = ({
       completedLabelKey: "Quest completed!",
       ctaLabelKey: "Mark as complete",
       modalSubtitleKey: "Share how you completed the quest",
-      placeholderTextKey: "Just completed today's quest!",
+      placeholderTextKey: "Just completed this quest!",
       unauthenticatedMessageKey: "You must be logged in to submit a quest.",
       successMessageKey: "Quest completed successfully!",
       sliderAccentColor: colors.sideQuest.base,

--- a/src/components/DiscussFab.tsx
+++ b/src/components/DiscussFab.tsx
@@ -8,10 +8,14 @@ import {
   Platform,
   Image,
   ScrollView,
+  Keyboard,
+  KeyboardEvent,
+  useWindowDimensions,
   ViewStyle,
   ImageStyle,
   TextStyle,
 } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { colors } from "../constants/Colors";
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
 import { Text } from "./StyledText";
@@ -30,7 +34,37 @@ interface DiscussFabProps {
 const DiscussFab = ({ onPostCreated, bottomOffset = 24 }: DiscussFabProps) => {
   const { user } = useAuth();
   const { t } = useLanguage();
+  const insets = useSafeAreaInsets();
+  const { height: screenHeight } = useWindowDimensions();
   const [modalVisible, setModalVisible] = useState(false);
+  const [keyboardVisible, setKeyboardVisible] = useState(false);
+  const resolvedBottomOffset = Math.max(bottomOffset, insets.bottom + 12);
+  const keyboardVerticalOffset = Platform.OS === "ios" ? Math.max(insets.top - 12, 0) : 0;
+  const modalMaxHeight = Math.round(screenHeight * 0.5);
+
+  React.useEffect(() => {
+    const syncKeyboardVisibility = (visible: boolean, event?: KeyboardEvent) => {
+      if (event && Platform.OS === "ios") {
+        Keyboard.scheduleLayoutAnimation(event);
+      }
+
+      setKeyboardVisible(visible);
+    };
+
+    const showSubscription = Keyboard.addListener(
+      Platform.OS === "ios" ? "keyboardWillChangeFrame" : "keyboardDidShow",
+      (event) => syncKeyboardVisibility(true, event)
+    );
+    const hideSubscription = Keyboard.addListener(
+      Platform.OS === "ios" ? "keyboardWillHide" : "keyboardDidHide",
+      (event) => syncKeyboardVisibility(false, event)
+    );
+
+    return () => {
+      showSubscription.remove();
+      hideSubscription.remove();
+    };
+  }, []);
 
   const {
     selectedMedia,
@@ -79,7 +113,7 @@ const DiscussFab = ({ onPostCreated, bottomOffset = 24 }: DiscussFabProps) => {
         iconPosition="start"
         onPress={handleOpen}
         showIcon
-        style={[fabStyle, { bottom: bottomOffset }]}
+        style={[fabStyle, { bottom: resolvedBottomOffset }]}
         title={t("Discuss")}
         tone="indigo"
         variant="pill"
@@ -91,20 +125,33 @@ const DiscussFab = ({ onPostCreated, bottomOffset = 24 }: DiscussFabProps) => {
         onRequestClose={() => setModalVisible(false)}
         statusBarTranslucent
       >
+        <View style={backdropStyle} />
         <KeyboardAvoidingView
           behavior={Platform.OS === "ios" ? "padding" : "height"}
           style={keyboardViewStyle}
-          keyboardVerticalOffset={Platform.OS === "ios" ? -64 : 0}
+          keyboardVerticalOffset={keyboardVerticalOffset}
         >
-          <View style={modalContainerStyle}>
+          <View
+            style={[
+              modalContainerStyle,
+              {
+                paddingTop: insets.top + 12,
+                paddingBottom: keyboardVisible ? 0 : insets.bottom + 12,
+                paddingHorizontal: "5%",
+              },
+            ]}
+          >
             <ScrollView
               style={modalScrollStyle}
-              contentContainerStyle={scrollContentStyle}
+              contentContainerStyle={[
+                scrollContentStyle,
+                { justifyContent: keyboardVisible ? "flex-start" : "center" },
+              ]}
               showsVerticalScrollIndicator={false}
               keyboardShouldPersistTaps="handled"
               keyboardDismissMode="on-drag"
             >
-              <View style={modalContentStyle}>
+              <View style={[modalContentStyle, { maxHeight: modalMaxHeight }]}>
                 <View style={modalHeaderStyle}>
                   <View style={headerGlowStyle} />
                   <View style={headerRingStyle} />
@@ -154,13 +201,13 @@ const DiscussFab = ({ onPostCreated, bottomOffset = 24 }: DiscussFabProps) => {
                     scrollEnabled
                     textAlignVertical="top"
                     autoFocus
-                  placeholder={t(
-                    "Share your thoughts, start a discussion, or share an achievement..."
-                  )}
-                  placeholderTextColor="#999"
-                  maxLength={1000}
-                  onChangeText={setPostText}
-                />
+                    placeholder={t(
+                      "Share your thoughts, start a discussion, or share an achievement..."
+                    )}
+                    placeholderTextColor="#999"
+                    maxLength={1000}
+                    onChangeText={setPostText}
+                  />
 
                   <View style={mediaUploadContainerStyle}>
                     <TouchableOpacity
@@ -234,22 +281,27 @@ const keyboardViewStyle: ViewStyle = {
   flex: 1,
 };
 
+const backdropStyle: ViewStyle = {
+  backgroundColor: "rgba(0,0,0,0.5)",
+  bottom: 0,
+  left: 0,
+  position: "absolute",
+  right: 0,
+  top: 0,
+};
+
 const modalContainerStyle: ViewStyle = {
   alignItems: "center",
-  backgroundColor: "rgba(0,0,0,0.5)",
   flex: 1,
-  justifyContent: "center",
 };
 
 const modalScrollStyle: ViewStyle = {
-  maxHeight: "100%",
+  flex: 1,
   width: "100%",
 };
 
 const scrollContentStyle: ViewStyle = {
   flexGrow: 1,
-  justifyContent: "center",
-  paddingHorizontal: "5%",
 };
 
 const modalContentStyle: ViewStyle = {
@@ -257,7 +309,7 @@ const modalContentStyle: ViewStyle = {
   borderColor: colors.light.accent2,
   borderRadius: 26,
   borderWidth: 1,
-  marginVertical: 20,
+  flex: 1,
   overflow: "hidden",
   padding: 0,
   shadowColor: "#000",
@@ -381,8 +433,9 @@ const textInputStyle: TextStyle = {
   borderColor: colors.light.accent2,
   borderRadius: 18,
   borderWidth: 1,
-  height: 130,
+  flex: 1,
   marginBottom: 6,
+  minHeight: 120,
   paddingHorizontal: 14,
   paddingVertical: 14,
   textAlignVertical: "top",
@@ -461,6 +514,7 @@ const progressBarFillStyle: ViewStyle = {
 };
 
 const modalBodyStyle: ViewStyle = {
+  flex: 1,
   padding: 20,
 };
 

--- a/src/components/DiscussFab.tsx
+++ b/src/components/DiscussFab.tsx
@@ -31,14 +31,13 @@ interface DiscussFabProps {
   bottomOffset?: number;
 }
 
-const DiscussFab = ({ onPostCreated, bottomOffset = 24 }: DiscussFabProps) => {
+const DiscussFab = ({ onPostCreated, bottomOffset = 16 }: DiscussFabProps) => {
   const { user } = useAuth();
   const { t } = useLanguage();
   const insets = useSafeAreaInsets();
   const { height: screenHeight } = useWindowDimensions();
   const [modalVisible, setModalVisible] = useState(false);
   const [keyboardVisible, setKeyboardVisible] = useState(false);
-  const resolvedBottomOffset = Math.max(bottomOffset, insets.bottom + 12);
   const keyboardVerticalOffset = Platform.OS === "ios" ? Math.max(insets.top - 12, 0) : 0;
   const modalMaxHeight = Math.round(screenHeight * 0.5);
 
@@ -113,7 +112,7 @@ const DiscussFab = ({ onPostCreated, bottomOffset = 24 }: DiscussFabProps) => {
         iconPosition="start"
         onPress={handleOpen}
         showIcon
-        style={[fabStyle, { bottom: resolvedBottomOffset }]}
+        style={[fabStyle, { bottom: bottomOffset }]}
         title={t("Discuss")}
         tone="indigo"
         variant="pill"

--- a/src/components/FeatureActionButton.tsx
+++ b/src/components/FeatureActionButton.tsx
@@ -123,19 +123,17 @@ export function FeatureActionButton({
       onPress={onPress}
       disabled={disabled}
     >
-      {!isPill && (
+      {!isPill && hasSubtitle && (
         <>
           <View
             style={[
               styles.glow,
-              !hasSubtitle && styles.compactCardGlow,
               { backgroundColor: completed ? "rgba(255,255,255,0.14)" : palette.glowColor },
             ]}
           />
           <View
             style={[
               styles.orbit,
-              !hasSubtitle && styles.compactCardOrbit,
               { borderColor: completed ? "rgba(255,255,255,0.16)" : palette.orbitColor },
             ]}
           />
@@ -236,12 +234,6 @@ const styles = StyleSheet.create({
   },
   compactCardContent: {
     minHeight: 28,
-  },
-  compactCardGlow: {
-    top: -28,
-  },
-  compactCardOrbit: {
-    top: 6,
   },
   compactCardTitle: {
     includeFontPadding: false,

--- a/src/components/Post.tsx
+++ b/src/components/Post.tsx
@@ -333,6 +333,13 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
     }
   };
 
+  const handleQuestPress = (e: GestureResponderEvent) => {
+    e.stopPropagation();
+    if (post.quest_id) {
+      router.push(`/quest/${post.quest_id}`);
+    }
+  };
+
   const isChallengePost = !!post.challenge_id;
   const isQuestPost = !!post.quest_id;
 
@@ -561,14 +568,16 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
         </>
       )}
       {isQuestPost && (
-        <View style={questBoxStyle}>
-          <View style={tagRowStyle}>
-            <Ionicons name="footsteps" size={14} color={colors.sideQuest.text} />
-            <Text style={questTitleStyle} numberOfLines={1} ellipsizeMode="tail">
-              <Text style={{ fontWeight: "bold" }}>{t("Quest:")}</Text> {post.quest_title}
-            </Text>
+        <TouchableOpacity onPress={handleQuestPress}>
+          <View style={questBoxStyle}>
+            <View style={tagRowStyle}>
+              <Ionicons name="footsteps" size={14} color={colors.sideQuest.text} />
+              <Text style={questTitleStyle} numberOfLines={1} ellipsizeMode="tail">
+                <Text style={{ fontWeight: "bold" }}>{t("Quest:")}</Text> {post.quest_title}
+              </Text>
+            </View>
           </View>
-        </View>
+        </TouchableOpacity>
       )}
       {post.body && !post.media?.file_path ? (
         <Pressable onPress={handleDoubleTap}>

--- a/src/components/Quest.tsx
+++ b/src/components/Quest.tsx
@@ -15,6 +15,7 @@ import CompletionCelebrationModal from "./CompletionCelebrationModal";
 
 interface QuestCardProps {
   quest: SideQuest;
+  eyebrowText?: string;
   tags?: string[];
 }
 
@@ -22,7 +23,7 @@ interface ShareQuestExperienceProps {
   quest: SideQuest;
 }
 
-export const QuestCard: React.FC<QuestCardProps> = ({ quest, tags }) => {
+export const QuestCard: React.FC<QuestCardProps> = ({ quest, eyebrowText, tags }) => {
   const { t } = useLanguage();
 
   return (
@@ -35,7 +36,7 @@ export const QuestCard: React.FC<QuestCardProps> = ({ quest, tags }) => {
 
         <View style={styles.heroHeaderContent}>
           <View style={styles.heroContent}>
-            <Text style={styles.heroEyebrow}>{t("Today's quest")}</Text>
+            <Text style={styles.heroEyebrow}>{eyebrowText || t("Today's quest")}</Text>
             <Text style={styles.heroTitle}>{quest.title}</Text>
 
             {tags && tags.length > 0 && (
@@ -128,7 +129,7 @@ export const ShareQuestExperience: React.FC<ShareQuestExperienceProps> = ({ ques
         variant="quest"
         variantId={quest.id}
         mediaPreview={submittedMediaPreview}
-        postText={submittedTextRef.current || t("Just completed today's quest!")}
+        postText={submittedTextRef.current || t("Just completed this quest!")}
       />
     </>
   );

--- a/src/components/Quest.tsx
+++ b/src/components/Quest.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { StyleSheet, View } from "react-native";
-import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "../contexts/AuthContext";
 import { useLanguage } from "../contexts/LanguageContext";
@@ -51,21 +50,6 @@ export const QuestCard: React.FC<QuestCardProps> = ({ quest, tags }) => {
             )}
           </View>
         </View>
-
-        {!!quest.instructions && (
-          <>
-            <View style={styles.heroDivider} />
-            <View style={styles.heroDetailSection}>
-              <View style={styles.heroDetailHeader}>
-                <View style={styles.heroDetailIcon}>
-                  <MaterialCommunityIcons name="compass-outline" size={16} color={colors.sideQuest.text} />
-                </View>
-                <Text style={styles.heroDetailLabel}>{t("Try this")}</Text>
-              </View>
-              <Text style={styles.heroDetailText}>{quest.instructions}</Text>
-            </View>
-          </>
-        )}
       </View>
     </View>
   );
@@ -143,38 +127,6 @@ export const ShareQuestExperience: React.FC<ShareQuestExperienceProps> = ({ ques
 };
 
 const styles = StyleSheet.create({
-  heroDetailHeader: {
-    alignItems: "center",
-    flexDirection: "row",
-    gap: 10,
-    marginBottom: 10,
-  },
-  heroDetailIcon: {
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  heroDetailLabel: {
-    color: colors.sideQuest.text,
-    fontSize: 12,
-    fontWeight: "700",
-    letterSpacing: 0.6,
-    textTransform: "uppercase",
-  },
-  heroDetailSection: {
-    backgroundColor: colors.sideQuest.bg,
-    paddingHorizontal: 22,
-    paddingTop: 18,
-    paddingBottom: 22,
-  },
-  heroDetailText: {
-    color: colors.light.text,
-    fontSize: 15,
-    lineHeight: 23,
-  },
-  heroDivider: {
-    backgroundColor: colors.sideQuest.border,
-    height: 1,
-  },
   heroCard: {
     backgroundColor: colors.sideQuest.bgAlt,
     borderColor: colors.sideQuest.bgBorder,

--- a/src/components/Quest.tsx
+++ b/src/components/Quest.tsx
@@ -37,7 +37,6 @@ export const QuestCard: React.FC<QuestCardProps> = ({ quest, tags }) => {
           <View style={styles.heroContent}>
             <Text style={styles.heroEyebrow}>{t("Today's quest")}</Text>
             <Text style={styles.heroTitle}>{quest.title}</Text>
-            {!!quest.summary && <Text style={styles.heroSummary}>{quest.summary}</Text>}
 
             {tags && tags.length > 0 && (
               <View style={styles.heroPills}>
@@ -50,6 +49,15 @@ export const QuestCard: React.FC<QuestCardProps> = ({ quest, tags }) => {
             )}
           </View>
         </View>
+
+        {!!quest.summary && (
+          <>
+            <View style={styles.heroDivider} />
+            <View style={styles.heroSummarySection}>
+              <Text style={styles.heroSummary}>{quest.summary}</Text>
+            </View>
+          </>
+        )}
       </View>
     </View>
   );
@@ -127,6 +135,10 @@ export const ShareQuestExperience: React.FC<ShareQuestExperienceProps> = ({ ques
 };
 
 const styles = StyleSheet.create({
+  heroDivider: {
+    backgroundColor: colors.sideQuest.border,
+    height: 1,
+  },
   heroCard: {
     backgroundColor: colors.sideQuest.bgAlt,
     borderColor: colors.sideQuest.bgBorder,
@@ -215,7 +227,12 @@ const styles = StyleSheet.create({
     color: colors.light.text,
     fontSize: 15,
     lineHeight: 22,
-    marginTop: 12,
+  },
+  heroSummarySection: {
+    backgroundColor: colors.sideQuest.bg,
+    paddingHorizontal: 22,
+    paddingTop: 18,
+    paddingBottom: 22,
   },
   heroTitle: {
     color: colors.light.text,

--- a/src/components/QuestPage.tsx
+++ b/src/components/QuestPage.tsx
@@ -1,0 +1,150 @@
+import React, { useMemo } from "react";
+import { ScrollView, StyleSheet, View } from "react-native";
+import { useLocalSearchParams } from "expo-router";
+import { useQuery } from "@tanstack/react-query";
+import { useAuth } from "../contexts/AuthContext";
+import { useLanguage } from "../contexts/LanguageContext";
+import { colors } from "../constants/Colors";
+import { sideQuestService } from "../services/sideQuestService";
+import { Loader } from "./Loader";
+import { QuestCard, ShareQuestExperience } from "./Quest";
+import { Text } from "./StyledText";
+
+function getLocalDayString() {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = `${now.getMonth() + 1}`.padStart(2, "0");
+  const day = `${now.getDate()}`.padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+export const QuestPage: React.FC = () => {
+  const { t, language } = useLanguage();
+  const { user } = useAuth();
+  const params = useLocalSearchParams();
+  const questId = params.id ? parseInt(String(params.id), 10) : undefined;
+  const localDay = useMemo(() => getLocalDayString(), []);
+
+  const drawHistoryQuery = useQuery({
+    queryKey: ["side-quest-draw-history", user?.id],
+    queryFn: () => sideQuestService.fetchDrawHistory(user!.id),
+    enabled: !!user?.id,
+    staleTime: 30000,
+  });
+
+  const historyEntry = useMemo(
+    () => drawHistoryQuery.data?.find(({ quest }) => quest.id === questId) ?? null,
+    [drawHistoryQuery.data, questId]
+  );
+
+  const drawDateLabel = useMemo(() => {
+    if (!historyEntry) return null;
+
+    const [year, month, day] = historyEntry.draw.local_day.split("-").map(Number);
+    const date = new Date(year, month - 1, day, 12);
+
+    return new Intl.DateTimeFormat(language === "it" ? "it-IT" : "en-US", {
+      weekday: "long",
+      month: "long",
+      day: "numeric",
+    }).format(date);
+  }, [historyEntry, language]);
+
+  if (drawHistoryQuery.isLoading) {
+    return <Loader />;
+  }
+
+  if (drawHistoryQuery.error) {
+    return (
+      <View style={[styles.container, styles.centered]}>
+        <Text style={styles.title}>{t("Error")}</Text>
+        <Text style={styles.subtitle}>{(drawHistoryQuery.error as Error).message}</Text>
+      </View>
+    );
+  }
+
+  if (!historyEntry || !questId) {
+    return (
+      <View style={[styles.container, styles.centered]}>
+        <Text style={styles.title}>{t("Quest not found")}</Text>
+      </View>
+    );
+  }
+
+  const isToday = historyEntry.draw.local_day === localDay;
+
+  return (
+    <ScrollView
+      style={styles.container}
+      contentContainerStyle={styles.content}
+      keyboardShouldPersistTaps="handled"
+      keyboardDismissMode="on-drag"
+    >
+      <View style={styles.heroSection}>
+        <View style={styles.eyebrowWrap}>
+          <Text style={styles.eyebrow}>{isToday ? t("Today's quest") : t("Past quest")}</Text>
+          {!!drawDateLabel && <Text style={styles.eyebrowSub}>{drawDateLabel}</Text>}
+        </View>
+
+        <QuestCard quest={historyEntry.quest} eyebrowText={isToday ? t("Today's quest") : t("Past quest")} />
+
+        <View style={styles.ctaWrap}>
+          <ShareQuestExperience quest={historyEntry.quest} />
+        </View>
+      </View>
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  centered: {
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 24,
+  },
+  container: {
+    backgroundColor: colors.light.background,
+    flex: 1,
+  },
+  content: {
+    paddingBottom: 32,
+  },
+  ctaWrap: {
+    alignSelf: "center",
+    width: "80%",
+  },
+  eyebrow: {
+    color: colors.sideQuest.text,
+    fontSize: 18,
+    fontWeight: "700",
+    textAlign: "center",
+  },
+  eyebrowSub: {
+    color: colors.light.lightText,
+    fontSize: 13,
+    marginTop: 4,
+    textAlign: "center",
+  },
+  eyebrowWrap: {
+    alignSelf: "center",
+    marginBottom: 20,
+    width: "80%",
+  },
+  heroSection: {
+    paddingHorizontal: 16,
+    paddingTop: 20,
+  },
+  subtitle: {
+    color: colors.light.lightText,
+    fontSize: 15,
+    lineHeight: 22,
+    marginTop: 8,
+    textAlign: "center",
+  },
+  title: {
+    color: colors.light.text,
+    fontSize: 20,
+    fontWeight: "700",
+    textAlign: "center",
+  },
+});

--- a/src/components/QuestPage.tsx
+++ b/src/components/QuestPage.tsx
@@ -25,6 +25,13 @@ export const QuestPage: React.FC = () => {
   const questId = params.id ? parseInt(String(params.id), 10) : undefined;
   const localDay = useMemo(() => getLocalDayString(), []);
 
+  const questQuery = useQuery({
+    queryKey: ["side-quest", questId],
+    queryFn: () => sideQuestService.fetchQuestById(questId!),
+    enabled: !!questId,
+    staleTime: 30000,
+  });
+
   const drawHistoryQuery = useQuery({
     queryKey: ["side-quest-draw-history", user?.id],
     queryFn: () => sideQuestService.fetchDrawHistory(user!.id),
@@ -36,6 +43,8 @@ export const QuestPage: React.FC = () => {
     () => drawHistoryQuery.data?.find(({ quest }) => quest.id === questId) ?? null,
     [drawHistoryQuery.data, questId]
   );
+
+  const canCompleteQuest = !!historyEntry;
 
   const drawDateLabel = useMemo(() => {
     if (!historyEntry) return null;
@@ -50,20 +59,20 @@ export const QuestPage: React.FC = () => {
     }).format(date);
   }, [historyEntry, language]);
 
-  if (drawHistoryQuery.isLoading) {
+  if (questQuery.isLoading || drawHistoryQuery.isLoading) {
     return <Loader />;
   }
 
-  if (drawHistoryQuery.error) {
+  if (questQuery.error || drawHistoryQuery.error) {
     return (
       <View style={[styles.container, styles.centered]}>
         <Text style={styles.title}>{t("Error")}</Text>
-        <Text style={styles.subtitle}>{(drawHistoryQuery.error as Error).message}</Text>
+        <Text style={styles.subtitle}>{((questQuery.error || drawHistoryQuery.error) as Error).message}</Text>
       </View>
     );
   }
 
-  if (!historyEntry || !questId) {
+  if (!questQuery.data || !questId) {
     return (
       <View style={[styles.container, styles.centered]}>
         <Text style={styles.title}>{t("Quest not found")}</Text>
@@ -71,7 +80,12 @@ export const QuestPage: React.FC = () => {
     );
   }
 
-  const isToday = historyEntry.draw.local_day === localDay;
+  const isToday = historyEntry?.draw.local_day === localDay;
+  const eyebrowText = canCompleteQuest
+    ? isToday
+      ? t("Today's quest")
+      : t("Past quest")
+    : t("Side quest");
 
   return (
     <ScrollView
@@ -82,15 +96,17 @@ export const QuestPage: React.FC = () => {
     >
       <View style={styles.heroSection}>
         <View style={styles.eyebrowWrap}>
-          <Text style={styles.eyebrow}>{isToday ? t("Today's quest") : t("Past quest")}</Text>
+          <Text style={styles.eyebrow}>{eyebrowText}</Text>
           {!!drawDateLabel && <Text style={styles.eyebrowSub}>{drawDateLabel}</Text>}
         </View>
 
-        <QuestCard quest={historyEntry.quest} eyebrowText={isToday ? t("Today's quest") : t("Past quest")} />
+        <QuestCard quest={questQuery.data} eyebrowText={eyebrowText} />
 
-        <View style={styles.ctaWrap}>
-          <ShareQuestExperience quest={historyEntry.quest} />
-        </View>
+        {canCompleteQuest && (
+          <View style={styles.ctaWrap}>
+            <ShareQuestExperience quest={questQuery.data} />
+          </View>
+        )}
       </View>
     </ScrollView>
   );

--- a/src/components/SideQuestPath.tsx
+++ b/src/components/SideQuestPath.tsx
@@ -322,22 +322,6 @@ export const SideQuestPath: React.FC = () => {
         todaysQuest={todaysQuest}
       />
 
-      {!isRevealing && pastDrawnQuests.length > 0 && (
-        <View style={styles.pastSection}>
-          <Text style={styles.sectionTitle}>{t("Past side quests")}</Text>
-          {pastDrawnQuests.map(({ draw, quest }) => (
-            <View key={draw.id} style={styles.pastQuestCard}>
-              <QuestPreviewCard
-                title={quest.title}
-                description={quest.summary}
-                footerLabel={formatQuestDateLabel(draw.local_day)}
-                onPress={() => router.push(`/quest/${quest.id}`)}
-              />
-            </View>
-          ))}
-        </View>
-      )}
-
       {!isRevealing && (
         <View style={styles.editPrefsWrap}>
           <Text style={styles.editPrefsPrompt}>{t("Want a different mix of side quests?")}</Text>
@@ -353,6 +337,22 @@ export const SideQuestPath: React.FC = () => {
           >
             <Text style={styles.editPrefsText}>{t("Edit preferences")}</Text>
           </TouchableOpacity>
+        </View>
+      )}
+
+      {!isRevealing && pastDrawnQuests.length > 0 && (
+        <View style={styles.pastSection}>
+          <Text style={styles.sectionTitle}>{t("Past side quests")}</Text>
+          {pastDrawnQuests.map(({ draw, quest }) => (
+            <View key={draw.id} style={styles.pastQuestCard}>
+              <QuestPreviewCard
+                title={quest.title}
+                description={quest.summary}
+                footerLabel={formatQuestDateLabel(draw.local_day)}
+                onPress={() => router.push(`/quest/${quest.id}`)}
+              />
+            </View>
+          ))}
         </View>
       )}
     </ScrollView>

--- a/src/components/SideQuestPath.tsx
+++ b/src/components/SideQuestPath.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Animated, ScrollView, StyleSheet, TouchableOpacity, View } from "react-native";
+import { router } from "expo-router";
 import { AppAlert } from "./AppAlert";
 import { Text } from "./StyledText";
 import { Loader } from "./Loader";
@@ -23,6 +24,7 @@ import {
 import { SideQuestDailyDraw } from "./sideQuest/SideQuestDailyDraw";
 import { SideQuestQuestionnaire } from "./sideQuest/SideQuestQuestionnaire";
 import { SideQuestResults } from "./sideQuest/SideQuestResults";
+import { QuestPreviewCard } from "./ChallengePreviewCard";
 
 function buildDraft(profile: ReturnType<typeof useSideQuests>["profile"]): SideQuestQuestionnaireDraft {
   if (!profile) return SIDE_QUEST_EMPTY_DRAFT;
@@ -46,6 +48,9 @@ export const SideQuestPath: React.FC = () => {
     rankedSideQuests,
     sideQuestsLoading,
     sideQuestsError,
+    drawHistory,
+    drawHistoryLoading,
+    drawHistoryError,
     todaysQuest,
     todaysQuestState,
     todaysQuestLoading,
@@ -62,16 +67,27 @@ export const SideQuestPath: React.FC = () => {
   const revealOpacity = useRef(new Animated.Value(1)).current;
   const needsOnboarding = !profile;
   const questionCount = 7;
-  const todaysDateLabel = useMemo(() => {
-    const [year, month, day] = localDay.split("-").map(Number);
-    const date = new Date(year, month - 1, day, 12);
+  const formatQuestDateLabel = useMemo(
+    () => (dayValue: string) => {
+      const [year, month, day] = dayValue.split("-").map(Number);
+      const date = new Date(year, month - 1, day, 12);
 
-    return new Intl.DateTimeFormat(language === "it" ? "it-IT" : "en-US", {
-      weekday: "long",
-      month: "long",
-      day: "numeric",
-    }).format(date);
-  }, [language, localDay]);
+      return new Intl.DateTimeFormat(language === "it" ? "it-IT" : "en-US", {
+        weekday: "long",
+        month: "long",
+        day: "numeric",
+      }).format(date);
+    },
+    [language]
+  );
+
+  const todaysDateLabel = useMemo(() => formatQuestDateLabel(localDay), [formatQuestDateLabel, localDay]);
+
+  const pastDrawnQuests = useMemo(
+    () =>
+      drawHistory.filter(({ draw }) => draw.local_day !== localDay),
+    [drawHistory, localDay]
+  );
 
   useEffect(() => {
     setDraft(buildDraft(profile));
@@ -252,7 +268,7 @@ export const SideQuestPath: React.FC = () => {
     );
   }
 
-  if (!isRevealing && (sideQuestsLoading || (todaysQuestLoading && !todaysQuest))) {
+  if (!isRevealing && (sideQuestsLoading || drawHistoryLoading || (todaysQuestLoading && !todaysQuest))) {
     return <Loader />;
   }
 
@@ -261,6 +277,15 @@ export const SideQuestPath: React.FC = () => {
       <View style={styles.centeredState}>
         <Text style={styles.pageTitle}>{t("Error")}</Text>
         <Text style={styles.subtitle}>{(sideQuestsError as Error).message}</Text>
+      </View>
+    );
+  }
+
+  if (drawHistoryError) {
+    return (
+      <View style={styles.centeredState}>
+        <Text style={styles.pageTitle}>{t("Error")}</Text>
+        <Text style={styles.subtitle}>{(drawHistoryError as Error).message}</Text>
       </View>
     );
   }
@@ -296,6 +321,22 @@ export const SideQuestPath: React.FC = () => {
         revealOpacity={revealOpacity}
         todaysQuest={todaysQuest}
       />
+
+      {!isRevealing && pastDrawnQuests.length > 0 && (
+        <View style={styles.pastSection}>
+          <Text style={styles.sectionTitle}>{t("Past side quests")}</Text>
+          {pastDrawnQuests.map(({ draw, quest }) => (
+            <View key={draw.id} style={styles.pastQuestCard}>
+              <QuestPreviewCard
+                title={quest.title}
+                description={quest.summary}
+                footerLabel={formatQuestDateLabel(draw.local_day)}
+                onPress={() => router.push(`/quest/${quest.id}`)}
+              />
+            </View>
+          ))}
+        </View>
+      )}
 
       {!isRevealing && (
         <View style={styles.editPrefsWrap}>
@@ -335,6 +376,12 @@ const styles = StyleSheet.create({
     padding: 16,
     paddingBottom: 32,
   },
+  pastQuestCard: {
+    marginBottom: 12,
+  },
+  pastSection: {
+    paddingTop: 28,
+  },
   editPrefs: {
     alignSelf: "center",
     paddingHorizontal: 12,
@@ -363,6 +410,12 @@ const styles = StyleSheet.create({
     fontWeight: "800",
     lineHeight: 34,
     marginBottom: 6,
+  },
+  sectionTitle: {
+    color: colors.sideQuest.text,
+    fontSize: 18,
+    fontWeight: "700",
+    marginBottom: 12,
   },
   subtitle: {
     color: colors.light.lightText,

--- a/src/components/esplora/DecorativeCardBackground.tsx
+++ b/src/components/esplora/DecorativeCardBackground.tsx
@@ -80,7 +80,11 @@ function hexToRgba(hex: string, alpha: number) {
   return `rgba(${red}, ${green}, ${blue}, ${alpha})`;
 }
 
-export const DecorativeCardBackground: React.FC<Props> = ({ category, variant, seed = 0 }) => {
+export const DecorativeCardBackground: React.FC<Props> = ({
+  category,
+  variant,
+  seed = 0,
+}) => {
   const [background, accent] = CATEGORY_GRADIENTS[category];
   const motifs = CATEGORY_MOTIF_FAMILIES[category];
   const motif = motifs[Math.abs(seed) % motifs.length];

--- a/src/components/sideQuest/SideQuestQuestionnaire.tsx
+++ b/src/components/sideQuest/SideQuestQuestionnaire.tsx
@@ -29,6 +29,8 @@ import {
 
 const QUESTION_SWIPE_DISTANCE_THRESHOLD = 90;
 const QUESTION_SWIPE_VELOCITY_THRESHOLD = 700;
+const INTRO_TOP_OFFSET = 16;
+const AnimatedScrollView = Animated.createAnimatedComponent(ScrollView);
 
 type SingleSelectSectionProps<T extends string> = {
   title: string;
@@ -156,6 +158,7 @@ export function SideQuestQuestionnaire({
   const [isTransitioning, setIsTransitioning] = useState(false);
   const [pageWidth, setPageWidth] = useState(0);
   const translateX = useRef(new Animated.Value(0)).current;
+  const introScrollY = useRef(new Animated.Value(0)).current;
   const autoAdvanceTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
@@ -416,13 +419,13 @@ export function SideQuestQuestionnaire({
   return (
     <SafeAreaView style={styles.container} edges={["bottom"]}>
       <View style={styles.questionnaireScreen}>
-        <View style={styles.questionnaireHeader}>
-          {!showingIntroStep && (
+        {!showingIntroStep && (
+          <View style={styles.questionnaireHeader}>
             <View style={styles.stepIndicatorRow}>
               <ProgressSegments total={questionnaireSteps.length} activeIndex={currentQuestionIndex} />
             </View>
-          )}
-        </View>
+          </View>
+        )}
 
         <View
           style={[
@@ -451,14 +454,36 @@ export function SideQuestQuestionnaire({
                 key={pageIndex < 0 ? "intro" : `question-${pageIndex}`}
                 style={[styles.questionnairePage, { width: Math.max(pageWidth, 1) }]}
               >
-                <ScrollView
+                <AnimatedScrollView
                   contentContainerStyle={styles.questionnaireContent}
                   keyboardShouldPersistTaps="handled"
+                  onScroll={
+                    pageIndex < 0
+                      ? Animated.event(
+                          [{ nativeEvent: { contentOffset: { y: introScrollY } } }],
+                          { useNativeDriver: true }
+                        )
+                      : undefined
+                  }
+                  scrollEventThrottle={16}
                   scrollEnabled={!isTransitioning}
                   showsVerticalScrollIndicator={false}
                 >
                   {pageIndex < 0 ? (
-                    <View style={styles.introSection}>
+                    <Animated.View
+                      style={[
+                        styles.introSection,
+                        {
+                          transform: [{
+                            translateY: introScrollY.interpolate({
+                              inputRange: [0, INTRO_TOP_OFFSET],
+                              outputRange: [INTRO_TOP_OFFSET, 0],
+                              extrapolate: "clamp",
+                            }),
+                          }],
+                        },
+                      ]}
+                    >
                       <View style={styles.introHero}>
                         <View style={styles.introHeroGlow} />
                         <View style={styles.introHeroLineOne} />
@@ -525,7 +550,7 @@ export function SideQuestQuestionnaire({
                         title={t("Let's begin")}
                         tone="coral"
                       />
-                    </View>
+                    </Animated.View>
                   ) : (
                     questionnaireSteps[pageIndex].render({
                       goNext: () => {
@@ -541,7 +566,7 @@ export function SideQuestQuestionnaire({
                       isTransitioning,
                     })
                   )}
-                </ScrollView>
+                </AnimatedScrollView>
               </View>
             ))}
           </Animated.View>
@@ -714,7 +739,6 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: "flex-start",
     paddingBottom: 24,
-    paddingTop: 10,
   },
   introTitle: {
     color: colors.light.text,

--- a/src/constants/translations.ts
+++ b/src/constants/translations.ts
@@ -451,7 +451,6 @@ export const translations = {
   "Why this works": "Perché funziona",
   "Try it like this": "Provala così",
   "What to do": "Cosa fare",
-  "Try this": "Prova questo",
   "Want a different mix of side quests?": "Vuoi un mix diverso di side quest?",
   "Edit preferences": "Modifica preferenze",
   "Back": "Indietro"

--- a/src/constants/translations.ts
+++ b/src/constants/translations.ts
@@ -266,6 +266,7 @@ export const translations = {
   "Quest completed successfully!": "Quest completata con successo!",
   "Share how you completed the quest": "Condividi come hai completato la quest",
   "Just completed today's quest!": "Ho appena completato la quest di oggi!",
+  "Just completed this quest!": "Ho appena completato questa quest!",
   "You must be logged in to submit a quest.": "Devi essere loggato per inviare una quest.",
   "Your quest of the day": "La tua quest del giorno",
   "Pick a quest": "Pesca una quest",
@@ -288,7 +289,14 @@ export const translations = {
   "Something went wrong. Tap to retry.":
     "Qualcosa è andato storto. Tocca per riprovare.",
   "Past challenges": "Sfide passate",
+  "Past quest": "Quest passata",
+  "Past side quests": "Quest passate",
+  "This side quest": "Questa side quest",
   "Just completed this week's challenge!": "Ho appena completato la sfida settimanale!",
+  "completed. Share it now.": "completata. Condividila ora.",
+  "Pull a friend into this adventure.": "Coinvolgi un amico in questa avventura.",
+  "I just completed a side quest on Stepn Out. Come try one too.\n\n(link)":
+    "Ho appena completato una side quest su Stepn Out. Provane una anche tu.\n\n(link)",
   "Share your thoughts...": "Condividi i tuoi pensieri...",
   "You must be logged in to submit a post.": "Devi essere loggato per pubblicare un post.",
   "Photo Access Required": "Accesso Foto Richiesto",
@@ -448,10 +456,12 @@ export const translations = {
   "Ranked to fit the kind of break from routine you want right now.": "Ordinate per adattarsi al tipo di deviazione dalla routine che vuoi in questo momento.",
   "No side quests yet.": "Nessuna side quest ancora.",
   "Once side quests are added, they will show up here ranked for your preferences.": "Quando aggiungeremo le side quest, appariranno qui ordinate in base alle tue preferenze.",
+  "Side quest": "Side quest",
   "Why this works": "Perché funziona",
   "Try it like this": "Provala così",
   "What to do": "Cosa fare",
   "Want a different mix of side quests?": "Vuoi un mix diverso di side quest?",
   "Edit preferences": "Modifica preferenze",
-  "Back": "Indietro"
+  "Back": "Indietro",
+  "Quest not found": "Quest non trovata"
 };

--- a/src/hooks/useSideQuests.ts
+++ b/src/hooks/useSideQuests.ts
@@ -54,6 +54,13 @@ export function useSideQuests() {
     staleTime: 30000,
   });
 
+  const drawHistoryQuery = useQuery({
+    queryKey: ["side-quest-draw-history", userId],
+    queryFn: () => sideQuestService.fetchDrawHistory(user!.id),
+    enabled: !!userId,
+    staleTime: 30000,
+  });
+
   const saveProfileMutation = useMutation({
     mutationFn: (draft: SideQuestQuestionnaireDraft) => sideQuestService.saveProfile(user!.id, draft),
     onMutate: async (draft) => {
@@ -74,6 +81,7 @@ export function useSideQuests() {
         queryClient.invalidateQueries({ queryKey: ["side-quest-profile", userId] }),
         queryClient.invalidateQueries({ queryKey: ["side-quests"] }),
         queryClient.invalidateQueries({ queryKey: ["side-quest-draw", userId, localDay] }),
+        queryClient.invalidateQueries({ queryKey: ["side-quest-draw-history", userId] }),
       ]);
     },
   });
@@ -94,7 +102,10 @@ export function useSideQuests() {
     mutationFn: () => sideQuestService.claimDailyQuest(user!.id, rankedSideQuests, localDay),
     onSuccess: async () => {
       if (!userId) return;
-      await queryClient.invalidateQueries({ queryKey: ["side-quest-draw", userId, localDay] });
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["side-quest-draw", userId, localDay] }),
+        queryClient.invalidateQueries({ queryKey: ["side-quest-draw-history", userId] }),
+      ]);
     },
   });
 
@@ -114,6 +125,9 @@ export function useSideQuests() {
     rankedSideQuests,
     sideQuestsLoading: sideQuestsQuery.isLoading,
     sideQuestsError: sideQuestsQuery.error,
+    drawHistory: drawHistoryQuery.data || [],
+    drawHistoryLoading: drawHistoryQuery.isLoading,
+    drawHistoryError: drawHistoryQuery.error,
     todaysQuest: dailyDrawQuery.data?.quest || drawDailyQuestMutation.data?.quest || null,
     todaysQuestDraw: dailyDrawQuery.data?.draw || drawDailyQuestMutation.data?.draw || null,
     todaysQuestState,

--- a/src/services/sideQuestService.ts
+++ b/src/services/sideQuestService.ts
@@ -278,6 +278,17 @@ export const sideQuestService = {
     return (data || []).map((row) => normalizeSideQuest(row as SideQuestRow));
   },
 
+  async fetchQuestById(questId: number): Promise<SideQuest | null> {
+    const { data, error } = await supabase
+      .from("side_quests")
+      .select("*")
+      .eq("id", questId)
+      .maybeSingle();
+
+    if (error) throw error;
+    return data ? normalizeSideQuest(data as SideQuestRow) : null;
+  },
+
   async fetchDailyDraw(userId: string, localDay: string): Promise<{ draw: SideQuestDraw; quest: SideQuest } | null> {
     const { data, error } = await supabase
       .from("side_quest_draws")

--- a/src/services/sideQuestService.ts
+++ b/src/services/sideQuestService.ts
@@ -1,5 +1,6 @@
 import { supabase } from "../lib/supabase";
 import {
+  DrawnSideQuest,
   RankedSideQuest,
   SideQuest,
   SideQuestAvoidType,
@@ -298,6 +299,34 @@ export const sideQuestService = {
       } as SideQuestDrawRow),
       quest: normalizeSideQuest(data.side_quests as unknown as SideQuestRow),
     };
+  },
+
+  async fetchDrawHistory(userId: string): Promise<DrawnSideQuest[]> {
+    const { data, error } = await supabase
+      .from("side_quest_draws")
+      .select("id, user_id, quest_id, local_day, created_at, side_quests (*)")
+      .eq("user_id", userId)
+      .order("local_day", { ascending: false })
+      .order("created_at", { ascending: false });
+
+    if (error) throw error;
+
+    return (data || []).reduce<DrawnSideQuest[]>((acc, row) => {
+      if (!row.side_quests) return acc;
+
+      acc.push({
+        draw: normalizeDraw({
+          id: row.id,
+          user_id: row.user_id,
+          quest_id: row.quest_id,
+          local_day: row.local_day,
+          created_at: row.created_at,
+        } as SideQuestDrawRow),
+        quest: normalizeSideQuest(row.side_quests as unknown as SideQuestRow),
+      });
+
+      return acc;
+    }, []);
   },
 
   async claimDailyQuest(userId: string, rankedQuests: RankedSideQuest[], localDay: string): Promise<{

--- a/src/types/sideQuests.ts
+++ b/src/types/sideQuests.ts
@@ -69,8 +69,6 @@ export interface SideQuest {
   id: number;
   title: string;
   summary: string;
-  why_it_hits: string;
-  instructions: string;
   goal_tags: SideQuestGoal[];
   barrier_tags: SideQuestHardSituation[];
   context_tags: SideQuestPreferredContext[];

--- a/src/types/sideQuests.ts
+++ b/src/types/sideQuests.ts
@@ -95,6 +95,11 @@ export interface SideQuestDraw {
   created_at: string;
 }
 
+export interface DrawnSideQuest {
+  draw: SideQuestDraw;
+  quest: SideQuest;
+}
+
 export interface RankedSideQuest extends SideQuest {
   match_score: number;
   matched_goal_tags: SideQuestGoal[];

--- a/supabase/migrations/20260215163600_add_profile_activity_feed_hydrated_rpc.sql
+++ b/supabase/migrations/20260215163600_add_profile_activity_feed_hydrated_rpc.sql
@@ -54,10 +54,8 @@ as $$
           'body', p.body,
           'media_id', p.media_id,
           'challenge_id', p.challenge_id,
-          'quest_id', p.quest_id,
           'is_welcome', p.is_welcome,
           'challenge_title', ch.title,
-          'quest_title', sq.title,
           'media', case
             when m.file_path is null then null
             else jsonb_build_object('file_path', m.file_path)
@@ -94,7 +92,6 @@ as $$
         from public.post p
         left join public.media m on m.id = p.media_id
         left join public.challenges ch on ch.id = p.challenge_id
-        left join public.side_quests sq on sq.id = p.quest_id
         where p.id = a.item_id
       )
       else null
@@ -120,13 +117,10 @@ as $$
               'id', p.id,
               'body', p.body,
               'created_at', p.created_at,
-              'challenge_title', ch.title,
-              'quest_id', p.quest_id,
-              'quest_title', sq.title
+              'challenge_title', ch.title
             )
             from public.post p
             left join public.challenges ch on ch.id = p.challenge_id
-            left join public.side_quests sq on sq.id = p.quest_id
             where p.id = c.post_id
           )
         )

--- a/supabase/migrations/20260503120000_add_daily_side_quest_draws_and_quest_posts.sql
+++ b/supabase/migrations/20260503120000_add_daily_side_quest_draws_and_quest_posts.sql
@@ -161,6 +161,154 @@ SET search_path = public;
 
 GRANT EXECUTE ON FUNCTION public.claim_daily_side_quest(bigint[], date) TO authenticated;
 
+CREATE OR REPLACE FUNCTION public.get_profile_activity_hydrated(
+  p_user_id uuid,
+  p_limit int DEFAULT 20,
+  p_before_created_at timestamptz DEFAULT NULL,
+  p_before_type text DEFAULT NULL,
+  p_before_id int DEFAULT NULL
+)
+RETURNS TABLE(
+  item_type text,
+  item_id int,
+  created_at timestamptz,
+  post jsonb,
+  comment jsonb
+)
+LANGUAGE sql
+STABLE
+AS $$
+  with activity as (
+    select
+      'post'::text as item_type,
+      p.id as item_id,
+      p.created_at as created_at
+    from public.post p
+    left join public.media m on m.id = p.media_id
+    where p.user_id = p_user_id
+      and coalesce(p.is_welcome, false) = false
+      and (
+        m.upload_status is null
+        or m.upload_status not in ('failed', 'pending')
+      )
+
+    union all
+
+    select
+      'comment'::text as item_type,
+      c.id as item_id,
+      c.created_at::timestamptz as created_at
+    from public.comments c
+    where c.user_id = p_user_id
+  )
+  select
+    a.item_type,
+    a.item_id,
+    a.created_at,
+    case
+      when a.item_type = 'post' then (
+        select jsonb_build_object(
+          'id', p.id,
+          'user_id', p.user_id,
+          'created_at', p.created_at,
+          'featured', p.featured,
+          'body', p.body,
+          'media_id', p.media_id,
+          'challenge_id', p.challenge_id,
+          'quest_id', p.quest_id,
+          'is_welcome', p.is_welcome,
+          'challenge_title', ch.title,
+          'quest_title', sq.title,
+          'media', case
+            when m.file_path is null then null
+            else jsonb_build_object('file_path', m.file_path)
+          end,
+          'likes_count', (select count(*) from public.likes l where l.post_id = p.id),
+          'comments_count', (select count(*) from public.comments c where c.post_id = p.id),
+          'liked', exists(
+            select 1
+            from public.likes l
+            where l.post_id = p.id
+              and l.user_id = auth.uid()
+          ),
+          'comment_previews', (
+            select coalesce(jsonb_agg(
+              jsonb_build_object(
+                'username', pr.username,
+                'text', c.body,
+                'replyToUsername', pr_parent.username
+              )
+              order by c.created_at asc
+            ), '[]'::jsonb)
+            from (
+              select c1.*
+              from public.comments c1
+              where c1.post_id = p.id
+              order by c1.created_at asc
+              limit 3
+            ) c
+            left join public.profiles pr on pr.id = c.user_id
+            left join public.comments c_parent on c_parent.id = c.parent_comment_id
+            left join public.profiles pr_parent on pr_parent.id = c_parent.user_id
+          )
+        )
+        from public.post p
+        left join public.media m on m.id = p.media_id
+        left join public.challenges ch on ch.id = p.challenge_id
+        left join public.side_quests sq on sq.id = p.quest_id
+        where p.id = a.item_id
+      )
+      else null
+    end as post,
+    case
+      when a.item_type = 'comment' then (
+        select jsonb_build_object(
+          'id', c.id,
+          'user_id', c.user_id,
+          'post_id', c.post_id,
+          'parent_comment_id', c.parent_comment_id,
+          'created_at', c.created_at,
+          'text', c.body,
+          'likes_count', (select count(*) from public.likes l where l.comment_id = c.id),
+          'liked', exists(
+            select 1
+            from public.likes l
+            where l.comment_id = c.id
+              and l.user_id = auth.uid()
+          ),
+          'post', (
+            select jsonb_build_object(
+              'id', p.id,
+              'body', p.body,
+              'created_at', p.created_at,
+              'challenge_title', ch.title,
+              'quest_id', p.quest_id,
+              'quest_title', sq.title
+            )
+            from public.post p
+            left join public.challenges ch on ch.id = p.challenge_id
+            left join public.side_quests sq on sq.id = p.quest_id
+            where p.id = c.post_id
+          )
+        )
+        from public.comments c
+        where c.id = a.item_id
+      )
+      else null
+    end as comment
+  from activity a
+  where (
+    p_before_created_at is null
+    or p_before_type is null
+    or p_before_id is null
+    or (a.created_at, a.item_type, a.item_id) < (p_before_created_at, p_before_type, p_before_id)
+  )
+  order by a.created_at desc, a.item_type desc, a.item_id desc
+  limit p_limit;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_profile_activity_hydrated(uuid, int, timestamptz, text, int) TO authenticated;
+
 CREATE OR REPLACE FUNCTION public.get_popular_post_ids(
   feed_type text,
   blocked_ids uuid[] DEFAULT '{}',

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -561,7 +561,19 @@ VALUES
   (30, '11111111-1111-1111-1111-111111111111', 'I tried the one-block safari quest after dinner and ended up noticing a tiny ceramics studio I''ve walked past for years without seeing.', null, 2, null, false, false, now() - interval '5 days'),
   (31, '33333333-3333-3333-3333-333333333333', 'Today''s quest was to find the best bench within walking distance. I tested three and fully support turning ordinary errands into field research.', null, 7, 18, false, false, now() - interval '2 days'),
   (32, '22222222-2222-2222-2222-222222222222', 'Picked a quest out of the hat and wound up borrowing a random cookbook from the library. Weirdly energizing.', null, 6, null, false, false, now() - interval '20 hours'),
-  (33, '44444444-4444-4444-4444-444444444444', 'Did the market color hunt quest and came home with an aggressively orange snack lineup. Zero regrets.', null, 8, 19, false, true, now() - interval '9 hours');
+  (33, '44444444-4444-4444-4444-444444444444', 'Did the market color hunt quest and came home with an aggressively orange snack lineup. Zero regrets.', null, 8, 19, false, true, now() - interval '9 hours'),
+  (34, '44444444-4444-4444-4444-444444444444', 'Took the tiny adventure prompt seriously and walked a route home I''d never tried. Found a mural and a bakery I somehow always missed.', null, 3, null, false, false, now() - interval '4 days'),
+  (35, '44444444-4444-4444-4444-444444444444', 'Used the quest as an excuse to linger in a bookstore and ask the staff for a weird recommendation. Ended up leaving with a poetry collection.', null, 5, null, false, false, now() - interval '2 days');
+
+-- Seed side quest draw history so quest-tagged seed posts also appear in side quest history
+INSERT INTO public.side_quest_draws (id, user_id, quest_id, local_day, created_at)
+VALUES
+  (1, '11111111-1111-1111-1111-111111111111', 2, current_date - 5, now() - interval '5 days'),
+  (2, '33333333-3333-3333-3333-333333333333', 7, current_date - 2, now() - interval '2 days'),
+  (3, '22222222-2222-2222-2222-222222222222', 6, current_date - 1, now() - interval '20 hours'),
+  (4, '44444444-4444-4444-4444-444444444444', 3, current_date - 4, now() - interval '4 days'),
+  (5, '44444444-4444-4444-4444-444444444444', 5, current_date - 2, now() - interval '2 days'),
+  (6, '44444444-4444-4444-4444-444444444444', 8, current_date, now() - interval '9 hours');
 
 -- Challenge submissions with default body (no custom text)
 INSERT INTO public.post (id, user_id, body, challenge_id, media_id, is_welcome, featured, created_at)
@@ -582,6 +594,7 @@ VALUES
   (29, '11111111-1111-1111-1111-111111111111', '', null, null, true, false, now() - interval '1 day');
 
 SELECT setval('public.post_id_seq', (SELECT MAX(id) FROM public.post));
+SELECT setval('public.side_quest_draws_id_seq', (SELECT MAX(id) FROM public.side_quest_draws));
 
 -- =============================================================================
 -- COMMENTS

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -63,10 +63,10 @@ VALUES
 SELECT setval('public.media_id_seq', (SELECT MAX(id) FROM public.media));
 
 -- Update profiles with full data (trigger created basic profiles)
-UPDATE public.profiles SET username = 'alice', name = 'Alice Johnson', is_admin = false, first_login = false, eula_accepted = true, profile_media_id = 10, created_at = now() - interval '30 days', updated_at = now() - interval '30 days' WHERE id = '11111111-1111-1111-1111-111111111111';
-UPDATE public.profiles SET username = 'bob', name = 'Bob Smith', is_admin = false, first_login = false, eula_accepted = true, profile_media_id = 11, created_at = now() - interval '30 days', updated_at = now() - interval '30 days' WHERE id = '22222222-2222-2222-2222-222222222222';
-UPDATE public.profiles SET username = 'charlie', name = 'Charlie Brown', is_admin = false, first_login = false, eula_accepted = true, profile_media_id = 12, created_at = now() - interval '30 days', updated_at = now() - interval '30 days' WHERE id = '33333333-3333-3333-3333-333333333333';
-UPDATE public.profiles SET username = 'admin', name = 'Admin User', is_admin = true, first_login = false, eula_accepted = true, profile_media_id = 13, created_at = now() - interval '30 days', updated_at = now() - interval '30 days' WHERE id = '44444444-4444-4444-4444-444444444444';
+UPDATE public.profiles SET username = 'alice', name = 'Alice Johnson', is_admin = false, first_login = false, eula_accepted = true, profile_media_id = 10, created_at = now() - interval '30 days' WHERE id = '11111111-1111-1111-1111-111111111111';
+UPDATE public.profiles SET username = 'bob', name = 'Bob Smith', is_admin = false, first_login = false, eula_accepted = true, profile_media_id = 11, created_at = now() - interval '30 days' WHERE id = '22222222-2222-2222-2222-222222222222';
+UPDATE public.profiles SET username = 'charlie', name = 'Charlie Brown', is_admin = false, first_login = false, eula_accepted = true, profile_media_id = 12, created_at = now() - interval '30 days' WHERE id = '33333333-3333-3333-3333-333333333333';
+UPDATE public.profiles SET username = 'admin', name = 'Admin User', is_admin = true, first_login = false, eula_accepted = true, profile_media_id = 13, created_at = now() - interval '30 days' WHERE id = '44444444-4444-4444-4444-444444444444';
 
 -- =============================================================================
 -- CHALLENGES


### PR DESCRIPTION
This PR updates side quests so drawn quests stick around as an ongoing backlog. Todays quest still sits at the top, past pulled quests show up below it, and any drawn quest can open its own detail page. Quests youve drawn can still be marked complete with a post tied to that quest, and quests pulled by other users can still be viewed from posts without exposing the completion action.

- Adds side quest draw history loading and a quest detail flow, plus seed data that gives local test users real quest history to browse.
- Updates the path screen to show past side quests beneath todays quest, move the preferences prompt closer to the main quest action, and route each past quest into its own detail page.
- Makes quest pills on posts clickable, opening the matching quest page the same way challenge pills open challenge pages.
- Tweaks quest copy and completion messaging so it fits any drawn quest, and folds in a few small UI polish updates around quest cards, compact action buttons, the questionnaire intro, the quest detail back button, and the discuss button position.