### PR TITLE
support multiple post media

### DIFF
--- a/src/components/Challenge.tsx
+++ b/src/components/Challenge.tsx
@@ -199,17 +199,19 @@ export const ShareExperience: React.FC<ShareExperienceProps> = ({ challenge }) =
           challenge_id: challenge.id,
           comfort_zone_rating: comfortRating,
         })}
-        onCompleted={({ selectedMedia, submittedText, comfortRating }) => {
+        onCompleted={({ selectedMediaItems, submittedText, comfortRating }) => {
+          const firstSelectedMedia = selectedMediaItems[0] || null;
           submittedTextRef.current = submittedText;
-          setSubmittedMediaPreview(selectedMedia?.previewUrl || null);
+          setSubmittedMediaPreview(firstSelectedMedia?.previewUrl || null);
           queryClient.setQueryData(["challenge-completion", challenge.id, user?.id], true);
           queryClient.invalidateQueries({ queryKey: ["home-posts"] });
           captureEvent(CHALLENGE_EVENTS.COMPLETED, {
             challenge_id: challenge.id,
             challenge_title: challenge.title,
             challenge_difficulty: challenge.difficulty,
-            has_media: !!selectedMedia,
-            is_video: selectedMedia?.isVideo || false,
+            has_media: selectedMediaItems.length > 0,
+            is_video: firstSelectedMedia?.isVideo || false,
+            media_count: selectedMediaItems.length,
             comfort_zone_rating: comfortRating,
           });
           setUserProperties({

--- a/src/components/CommentPreviewRow.tsx
+++ b/src/components/CommentPreviewRow.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { View, Text, ViewStyle, TextStyle } from "react-native";
+import MaterialIcons from "@expo/vector-icons/MaterialIcons";
 import { colors } from "../constants/Colors";
 
 type CommentPreviewRowProps = {
@@ -8,6 +9,7 @@ type CommentPreviewRowProps = {
   replyToUsername?: string;
   isLast?: boolean;
   bodyColor?: string;
+  hasMedia?: boolean;
 };
 
 const CommentPreviewRow: React.FC<CommentPreviewRowProps> = ({
@@ -16,6 +18,7 @@ const CommentPreviewRow: React.FC<CommentPreviewRowProps> = ({
   replyToUsername,
   isLast = true,
   bodyColor = colors.neutral.darkGrey,
+  hasMedia = false,
 }) => {
   return (
     <View style={rowStyle}>
@@ -24,10 +27,18 @@ const CommentPreviewRow: React.FC<CommentPreviewRowProps> = ({
       <Text style={[textStyle, { flex: 1 }]} numberOfLines={2}>
         <Text style={usernameStyle}>@{username}:</Text>
         {"  "}
-        {replyToUsername && (
+        {replyToUsername ? (
           <Text style={{ color: bodyColor }}>@{replyToUsername} </Text>
+        ) : null}
+        {hasMedia ? (
+          <>
+            <MaterialIcons name="image" size={13} color={bodyColor} />
+            {" "}
+          </>
+        ) : null}
+        {!text && hasMedia ? null : (
+          <Text style={{ color: bodyColor }}>{text}</Text>
         )}
-        <Text style={{ color: bodyColor }}>{text}</Text>
       </Text>
     </View>
   );

--- a/src/components/Comments.tsx
+++ b/src/components/Comments.tsx
@@ -8,13 +8,14 @@ import {
   Animated,
   PanResponder,
   TouchableOpacity,
+  Modal,
   ViewStyle,
   TextStyle,
   ImageStyle,
   ActivityIndicator,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { MaterialCommunityIcons } from "@expo/vector-icons";
+import { MaterialCommunityIcons, MaterialIcons } from "@expo/vector-icons";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { Text } from "./StyledText";
@@ -35,6 +36,11 @@ import { ActionsMenu } from "./ActionsMenu";
 import { captureEvent } from "../lib/posthog";
 import { COMMENT_EVENTS } from "../constants/analyticsEvents";
 import { translationService } from "../services/translationService";
+import { MediaSelectionResult } from "../utils/handleMediaUpload";
+import { MediaGrid } from "./MediaGrid";
+import { useMediaSelection } from "../hooks/useMediaSelection";
+import ImageViewer from "react-native-image-zoom-viewer";
+import VideoPlayer from "./VideoPlayer";
 
 interface CommentsProps {
   initialComments: CommentType[];
@@ -43,7 +49,12 @@ interface CommentsProps {
   postId: number;
   postUserId: string;
   onCommentAdded?: (newCount: number) => void;
-  addComment: (userId: string, body: string, parentCommentId?: number | null) => Promise<CommentType | null>;
+  addComment: (
+    userId: string,
+    body: string,
+    parentCommentId?: number | null,
+    mediaItems?: MediaSelectionResult[]
+  ) => Promise<CommentType | null>;
   isAddingComment?: boolean;
 }
 
@@ -55,7 +66,12 @@ interface CommentsListProps {
   postId: number;
   postUserId: string;
   onCommentAdded?: (newCount: number) => void;
-  addComment: (userId: string, body: string, parentCommentId?: number | null) => Promise<CommentType | null>;
+  addComment: (
+    userId: string,
+    body: string,
+    parentCommentId?: number | null,
+    mediaItems?: MediaSelectionResult[]
+  ) => Promise<CommentType | null>;
   isAddingComment?: boolean;
 }
 
@@ -66,6 +82,8 @@ type DisplayComment = CommentType & {
   isLastReply?: boolean;
   replyToUserId?: string;
 };
+
+type CommentMediaItem = NonNullable<CommentType["media_items"]>[number];
 
 const getRootCommentId = (commentsById: Map<number, CommentType>, comment: CommentType) => {
   const visited = new Set<number>();
@@ -143,6 +161,13 @@ export const CommentsList: React.FC<CommentsListProps> = ({
   const [newComment, setNewComment] = useState("");
   const [replyTo, setReplyTo] = useState<{ commentId: number; userId: string; username: string } | null>(null);
   const [comments, setComments] = useState(initialComments);
+  const {
+    selectedMediaItems,
+    isUploading,
+    handleMediaUpload,
+    handleRemoveMedia,
+    clearMedia,
+  } = useMediaSelection();
 
   useEffect(() => {
     setComments(initialComments);
@@ -151,19 +176,25 @@ export const CommentsList: React.FC<CommentsListProps> = ({
       initializeCommentLikes(initialComments);
       initializeCommentReactions(initialComments);
     }
-  }, [initialComments]);
+  }, [initialComments, initializeCommentLikes, initializeCommentReactions]);
 
   const handleAddComment = async () => {
-    if (newComment.trim() && user) {
+    if ((newComment.trim() || selectedMediaItems.length > 0) && user) {
       const commentText = newComment.trim();
 
       try {
         const parentCommentId = replyTo?.commentId ?? null;
-        const newCommentData = await addComment(user.id, commentText, parentCommentId);
+        const newCommentData = await addComment(
+          user.id,
+          commentText,
+          parentCommentId,
+          selectedMediaItems
+        );
 
         if (newCommentData) {
           setNewComment("");
           setReplyTo(null);
+          clearMedia();
 
           setComments((prevComments) => [...prevComments, newCommentData]);
 
@@ -197,7 +228,7 @@ export const CommentsList: React.FC<CommentsListProps> = ({
                   senderUsername,
                   recipientId,
                   postId.toString(),
-                  commentText,
+                  commentText || "🖼️",
                   newCommentData.id.toString(),
                   {
                     title: t("(username) commented"),
@@ -215,6 +246,7 @@ export const CommentsList: React.FC<CommentsListProps> = ({
             comment_id: newCommentData.id,
             comment_length: commentText.length,
             is_reply: !!parentCommentId,
+            media_count: selectedMediaItems.length,
           });
         }
       } catch (error) {
@@ -263,6 +295,7 @@ export const CommentsList: React.FC<CommentsListProps> = ({
               text={item.text}
               created_at={item.created_at}
               post_id={item.post_id}
+              mediaItems={item.media_items}
               indentLevel={item.indentLevel}
               isLastReply={item.isLastReply}
               replyToUserId={item.replyToUserId}
@@ -280,6 +313,18 @@ export const CommentsList: React.FC<CommentsListProps> = ({
         />
 
         <View style={inputWrapperStyle}>
+          {selectedMediaItems.length > 0 ? (
+            <MediaGrid
+              items={selectedMediaItems.map((item) => ({
+                uri: item.thumbnailUri || item.previewUrl,
+                isVideo: item.isVideo,
+                useImageForVideo: true,
+              }))}
+              onRemove={handleRemoveMedia}
+              height={132}
+              style={commentMediaPreviewStyle}
+            />
+          ) : null}
           {replyTo ? (
             <View style={replyToContainerStyle}>
               <Text style={replyToTextStyle}>{t("Replying to")} @{replyTo.username}</Text>
@@ -289,6 +334,20 @@ export const CommentsList: React.FC<CommentsListProps> = ({
             </View>
           ) : null}
           <View style={inputContainerStyle}>
+            <TouchableOpacity
+              style={[
+                commentMediaButtonStyle,
+                selectedMediaItems.length >= 4 ? commentMediaButtonDisabledStyle : null,
+              ]}
+              onPress={handleMediaUpload}
+              disabled={selectedMediaItems.length >= 4 || isUploading || isAddingComment}
+            >
+              <MaterialIcons
+                name="add-photo-alternate"
+                size={20}
+                color={colors.light.primary}
+              />
+            </TouchableOpacity>
             <View style={inputInnerContainerStyle}>
               <TextInput
                 value={newComment}
@@ -304,10 +363,10 @@ export const CommentsList: React.FC<CommentsListProps> = ({
               onPress={handleAddComment}
               style={({ pressed }) => [
                 postButtonStyle,
-                (!user || isAddingComment) && postButtonDisabledStyle,
+                (!user || isAddingComment || isUploading) && postButtonDisabledStyle,
                 pressed && postButtonPressedStyle,
               ]}
-              disabled={!user || isAddingComment}
+              disabled={!user || isAddingComment || isUploading}
             >
               <Text style={postButtonTextStyle}>
                 {isAddingComment ? t("Posting...") : t("Post")}
@@ -408,6 +467,7 @@ interface CommentProps {
   text: string;
   created_at: string;
   post_id: number;
+  mediaItems?: CommentType["media_items"];
   indentLevel?: number;
   isLastReply?: boolean;
   replyToUserId?: string;
@@ -421,6 +481,7 @@ const Comment: React.FC<CommentProps> = ({
   text,
   created_at,
   post_id,
+  mediaItems,
   indentLevel = 0,
   isLastReply = false,
   replyToUserId,
@@ -436,6 +497,10 @@ const Comment: React.FC<CommentProps> = ({
   const [replyToUser, setReplyToUser] = useState<User | null>(null);
   const [translatedText, setTranslatedText] = useState<string | null>(null);
   const [isTranslating, setIsTranslating] = useState(false);
+  const [showFullScreenImage, setShowFullScreenImage] = useState(false);
+  const [showVideoModal, setShowVideoModal] = useState(false);
+  const [selectedMediaIndex, setSelectedMediaIndex] = useState(0);
+  const [selectedImageViewerIndex, setSelectedImageViewerIndex] = useState(0);
 
   useEffect(() => {
     const loadUser = async () => {
@@ -485,6 +550,33 @@ const Comment: React.FC<CommentProps> = ({
     } else if (result.error) {
       console.error('Translation error:', result.error);
     }
+  };
+
+  const isVideo = (source?: string | null, mediaItem?: CommentMediaItem) => {
+    if (mediaItem?.is_video != null) return mediaItem.is_video;
+    return !!source?.match(/\.(mp4|mov|avi|wmv)$/i);
+  };
+
+  const imageViewerItems = (mediaItems || []).filter(
+    (item) => item.file_path && !isVideo(item.file_path, item)
+  );
+
+  const handleMediaPress = (mediaIndex: number) => {
+    const item = mediaItems?.[mediaIndex];
+    if (!item?.file_path) return;
+
+    setSelectedMediaIndex(mediaIndex);
+    if (isVideo(item.file_path, item)) {
+      setShowVideoModal(true);
+      return;
+    }
+
+    const imageIndex = (mediaItems || [])
+      .slice(0, mediaIndex)
+      .filter((mediaItem) => mediaItem.file_path && !isVideo(mediaItem.file_path, mediaItem))
+      .length;
+    setSelectedImageViewerIndex(imageIndex);
+    setShowFullScreenImage(true);
   };
 
   return (
@@ -548,12 +640,59 @@ const Comment: React.FC<CommentProps> = ({
           </View>
         </View>
         <View style={commentTextContainerStyle}>
-          <Text style={commentTextStyle}>
-            {indentLevel && replyToUser?.username ? (
-              <Text style={replyToUsernameStyle}>@{replyToUser.username} </Text>
-            ) : null}
-            {text}
-          </Text>
+          {text ? (
+            <Text style={commentTextStyle}>
+              {indentLevel && replyToUser?.username ? (
+                <Text style={replyToUsernameStyle}>@{replyToUser.username} </Text>
+              ) : null}
+              {text}
+            </Text>
+          ) : null}
+          {mediaItems && mediaItems.length > 0 ? (
+            <>
+              <MediaGrid
+                items={mediaItems
+                  .filter((item) => item.file_path)
+                  .map((item) => ({
+                    uri: item.preview_path || item.file_path || "",
+                    isVideo: isVideo(item.file_path, item),
+                    useImageForVideo: isVideo(item.file_path, item) && !!item.preview_path,
+                  }))}
+                onPress={handleMediaPress}
+                height={170}
+                style={commentMediaGridStyle}
+              />
+              <VideoPlayer
+                videoUri={mediaItems[selectedMediaIndex]?.file_path || ""}
+                visible={showVideoModal}
+                onClose={() => setShowVideoModal(false)}
+              />
+              <Modal
+                animationType="fade"
+                transparent
+                visible={showFullScreenImage}
+                onRequestClose={() => setShowFullScreenImage(false)}
+              >
+                <View style={fullScreenContainerStyle}>
+                  <TouchableOpacity
+                    style={closeFullScreenButtonStyle}
+                    onPress={() => setShowFullScreenImage(false)}
+                  >
+                    <MaterialCommunityIcons name="close" size={28} color="white" />
+                  </TouchableOpacity>
+                  <ImageViewer
+                    imageUrls={imageViewerItems.map((item) => ({ url: item.file_path || "" }))}
+                    index={selectedImageViewerIndex}
+                    enableSwipeDown
+                    onSwipeDown={() => setShowFullScreenImage(false)}
+                    renderIndicator={() => <></>}
+                    backgroundColor="rgba(0, 0, 0, 0.95)"
+                    onClick={() => setShowFullScreenImage(false)}
+                  />
+                </View>
+              </Modal>
+            </>
+          ) : null}
           {translatedText && (
             <View style={translationContainerStyle}>
               <Text style={translationLabelStyle}>Translation:</Text>
@@ -641,6 +780,11 @@ const commentTextStyle: TextStyle = {
   fontSize: 14,
 };
 
+const commentMediaGridStyle: ViewStyle = {
+  marginTop: 8,
+  width: "100%",
+};
+
 const replyToUsernameStyle: TextStyle = {
   color: colors.neutral.grey1,
   fontWeight: "600",
@@ -719,7 +863,23 @@ const inputContainerStyle: ViewStyle = {
 
 const inputInnerContainerStyle: ViewStyle = {
   flex: 1,
-  marginRight: 10,
+};
+
+const commentMediaButtonStyle: ViewStyle = {
+  alignItems: "center",
+  justifyContent: "center",
+  marginRight: 8,
+  paddingHorizontal: 4,
+  paddingVertical: 10,
+};
+
+const commentMediaButtonDisabledStyle: ViewStyle = {
+  opacity: 0.45,
+};
+
+const commentMediaPreviewStyle: ViewStyle = {
+  marginBottom: 8,
+  width: "100%",
 };
 
 const replyToContainerStyle: ViewStyle = {
@@ -781,6 +941,19 @@ const postButtonPressedStyle: ViewStyle = {
   opacity: 0.7,
 };
 
+const fullScreenContainerStyle: ViewStyle = {
+  backgroundColor: "rgba(0, 0, 0, 0.95)",
+  flex: 1,
+};
+
+const closeFullScreenButtonStyle: ViewStyle = {
+  padding: 8,
+  position: "absolute",
+  right: 16,
+  top: 50,
+  zIndex: 10,
+};
+
 const commentHeaderStyle: ViewStyle = {
   flexDirection: "row",
   justifyContent: "space-between",
@@ -801,12 +974,6 @@ const iconContainerStyle: ViewStyle = {
   flexDirection: "row",
   alignItems: "center",
   marginRight: 16,
-};
-
-const iconTextStyle: TextStyle = {
-  fontSize: 12,
-  color: colors.neutral.grey1,
-  marginLeft: 4,
 };
 
 const translationContainerStyle: ViewStyle = {

--- a/src/components/CompletionPostComposer.tsx
+++ b/src/components/CompletionPostComposer.tsx
@@ -351,6 +351,7 @@ export const CompletionPostComposer: React.FC<CompletionPostComposerProps> = ({
               }))}
               height={420}
               style={styles.fullScreenImage}
+              onPress={() => setFullScreenPreview(false)}
             />
           </View>
         </TouchableOpacity>

--- a/src/components/CompletionPostComposer.tsx
+++ b/src/components/CompletionPostComposer.tsx
@@ -31,7 +31,7 @@ interface CompletionPostComposerProps {
   checkingCompletion: boolean;
   buildSubmitData: (args: { userId: string; comfortRating: number | null }) => Record<string, unknown>;
   onCompleted: (args: {
-    selectedMedia: MediaSelectionResult | null;
+    selectedMediaItems: MediaSelectionResult[];
     submittedText: string;
     comfortRating: number | null;
   }) => void;
@@ -99,7 +99,6 @@ export const CompletionPostComposer: React.FC<CompletionPostComposerProps> = ({
   }[variant];
 
   const {
-    selectedMedia,
     selectedMediaItems,
     postText,
     setPostText,
@@ -112,7 +111,7 @@ export const CompletionPostComposer: React.FC<CompletionPostComposerProps> = ({
     onUploadComplete: () => {
       setModalVisible(false);
       onCompleted({
-        selectedMedia,
+        selectedMediaItems,
         submittedText: submittedTextRef.current || t(config.placeholderTextKey),
         comfortRating: showComfortSlider ? comfortRating : null,
       });

--- a/src/components/CompletionPostComposer.tsx
+++ b/src/components/CompletionPostComposer.tsx
@@ -1,7 +1,6 @@
 import React, { useRef, useState } from "react";
 import {
   Animated,
-  Image,
   KeyboardAvoidingView,
   Modal,
   Platform,
@@ -22,6 +21,7 @@ import { MediaSelectionResult } from "../utils/handleMediaUpload";
 import { FeatureActionButton } from "./FeatureActionButton";
 import { captureEvent } from "../lib/posthog";
 import { CHALLENGE_EVENTS } from "../constants/analyticsEvents";
+import { MediaGrid } from "./MediaGrid";
 
 type CompletionPostComposerVariant = "challenge" | "quest";
 
@@ -100,6 +100,7 @@ export const CompletionPostComposer: React.FC<CompletionPostComposerProps> = ({
 
   const {
     selectedMedia,
+    selectedMediaItems,
     postText,
     setPostText,
     isSubmitting,
@@ -221,31 +222,18 @@ export const CompletionPostComposer: React.FC<CompletionPostComposerProps> = ({
                   keyboardDismissMode="on-drag"
                 >
                   <View style={styles.modalBody}>
-                    {selectedMedia ? (
-                      <TouchableOpacity
-                        style={styles.mediaPreviewContainer}
+                    {selectedMediaItems.length > 0 ? (
+                      <MediaGrid
+                        items={selectedMediaItems.map((item) => ({
+                          uri: item.thumbnailUri || item.previewUrl,
+                          isVideo: item.isVideo,
+                          useImageForVideo: true,
+                        }))}
                         onPress={() => setFullScreenPreview(true)}
-                        disabled={false}
-                        activeOpacity={0.92}
-                      >
-                        <Image
-                          source={{ uri: selectedMedia.thumbnailUri || selectedMedia.previewUrl }}
-                          style={styles.mediaPreview}
-                          resizeMode="cover"
-                        />
-                        {selectedMedia.isVideo && (
-                          <View style={styles.mediaPreviewPlayOverlay}>
-                            <MaterialIcons name="play-circle-filled" size={26} color="white" />
-                          </View>
-                        )}
-                        <TouchableOpacity
-                          style={styles.removeMediaButton}
-                          onPress={handleRemoveMedia}
-                          disabled={false}
-                        >
-                          <MaterialIcons name="close" size={12} color="white" />
-                        </TouchableOpacity>
-                      </TouchableOpacity>
+                        onRemove={handleRemoveMedia}
+                        height={180}
+                        style={styles.mediaPreviewContainer}
+                      />
                     ) : null}
 
                     {uploadProgress !== null && (
@@ -307,20 +295,20 @@ export const CompletionPostComposer: React.FC<CompletionPostComposerProps> = ({
                         backgroundColor: config.actionBackgroundColor,
                         borderColor: config.actionBorderColor,
                       },
-                      selectedMedia ? styles.mediaActionButtonDisabled : null,
+                      selectedMediaItems.length >= 4 ? styles.mediaActionButtonDisabled : null,
                     ]}
                     onPress={handleMediaUpload}
-                    disabled={!!selectedMedia}
+                    disabled={selectedMediaItems.length >= 4}
                   >
                     <MaterialIcons
                       name="add-photo-alternate"
                       size={20}
-                      color={selectedMedia ? colors.neutral.darkGrey : config.headerAccentColor}
+                      color={selectedMediaItems.length >= 4 ? colors.neutral.darkGrey : config.headerAccentColor}
                     />
                     <Text
                       style={[
                         styles.mediaActionText,
-                        { color: selectedMedia ? colors.neutral.darkGrey : config.headerAccentColor },
+                        { color: selectedMediaItems.length >= 4 ? colors.neutral.darkGrey : config.headerAccentColor },
                       ]}
                     >
                       {t("Add media")}
@@ -356,10 +344,14 @@ export const CompletionPostComposer: React.FC<CompletionPostComposerProps> = ({
           onPress={() => setFullScreenPreview(false)}
         >
           <View style={styles.fullScreenImageWrapper}>
-            <Image
-              source={{ uri: selectedMedia?.previewUrl || "" }}
+            <MediaGrid
+              items={selectedMediaItems.map((item) => ({
+                uri: item.thumbnailUri || item.previewUrl,
+                isVideo: item.isVideo,
+                useImageForVideo: true,
+              }))}
+              height={420}
               style={styles.fullScreenImage}
-              resizeMode="contain"
             />
           </View>
         </TouchableOpacity>
@@ -520,30 +512,9 @@ const styles = StyleSheet.create({
     marginBottom: 6,
     maxWidth: "82%",
   },
-  mediaPreview: {
-    backgroundColor: colors.light.accent3,
-    borderRadius: 18,
-    height: "100%",
-    width: "100%",
-  },
   mediaPreviewContainer: {
-    borderRadius: 18,
-    height: 96,
     marginBottom: 4,
-    overflow: "hidden",
-    position: "relative",
     width: "100%",
-  },
-  mediaPreviewPlayOverlay: {
-    alignItems: "center",
-    backgroundColor: "rgba(0,0,0,0.35)",
-    borderRadius: 18,
-    bottom: 0,
-    justifyContent: "center",
-    left: 0,
-    position: "absolute",
-    right: 0,
-    top: 0,
   },
   progressBarContainer: {
     backgroundColor: "#ddd",
@@ -555,17 +526,6 @@ const styles = StyleSheet.create({
     backgroundColor: colors.light.accent,
     borderRadius: 2,
     height: "100%",
-  },
-  removeMediaButton: {
-    alignItems: "center",
-    backgroundColor: "rgba(0,0,0,0.5)",
-    borderRadius: 12,
-    height: 18,
-    justifyContent: "center",
-    position: "absolute",
-    right: 8,
-    top: 8,
-    width: 18,
   },
   sliderEndLabel: {
     fontSize: 13,

--- a/src/components/CreatePost.tsx
+++ b/src/components/CreatePost.tsx
@@ -6,11 +6,9 @@ import {
   TextInput,
   KeyboardAvoidingView,
   Platform,
-  Image,
   ScrollView,
   TextStyle,
   ViewStyle,
-  ImageStyle,
 } from "react-native";
 import { colors } from "../constants/Colors";
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
@@ -22,6 +20,7 @@ import { useMediaUpload } from "../hooks/useMediaUpload";
 import { captureEvent } from "../lib/posthog";
 import { POST_EVENTS } from "../constants/analyticsEvents";
 import { FeatureActionButton } from "./FeatureActionButton";
+import { MediaGrid } from "./MediaGrid";
 
 interface CreatePostProps {
   onPostCreated?: () => void;
@@ -35,6 +34,7 @@ const CreatePost = ({ onPostCreated }: CreatePostProps) => {
 
   const {
     selectedMedia,
+    selectedMediaItems,
     setPostText,
     isUploading,
     uploadProgress,
@@ -111,26 +111,17 @@ const CreatePost = ({ onPostCreated }: CreatePostProps) => {
                   <View style={mediaPreviewContainerStyle}>
                     <Loader />
                   </View>
-                ) : selectedMedia ? (
-                  <View style={mediaPreviewContainerStyle}>
-                    <Image
-                      source={{ 
-                        uri: selectedMedia.isVideo 
-                          ? selectedMedia.thumbnailUri || selectedMedia.previewUrl 
-                          : selectedMedia.previewUrl 
-                      }}
-                      style={mediaPreviewStyle}
-                      resizeMode="contain"
-                    />
-                    <TouchableOpacity style={removeMediaButtonStyle} onPress={handleRemoveMedia}>
-                      <MaterialIcons name="close" size={12} color="white" />
-                    </TouchableOpacity>
-                    {selectedMedia.isVideo && (
-                      <View style={videoIndicatorStyle}>
-                        <MaterialIcons name="play-circle-filled" size={24} color="white" />
-                      </View>
-                    )}
-                  </View>
+                ) : selectedMediaItems.length > 0 ? (
+                  <MediaGrid
+                    items={selectedMediaItems.map((item) => ({
+                      uri: item.thumbnailUri || item.previewUrl,
+                      isVideo: item.isVideo,
+                      useImageForVideo: true,
+                    }))}
+                    onRemove={handleRemoveMedia}
+                    height={240}
+                    style={mediaPreviewContainerStyle}
+                  />
                 ) : null}
 
                 <TextInput
@@ -203,19 +194,8 @@ const keyboardViewStyle: ViewStyle = {
 };
 
 const mediaPreviewContainerStyle: ViewStyle = {
-  position: "relative",
   width: "100%",
-  aspectRatio: 1.5,
-  borderRadius: 8,
   marginVertical: 10,
-  overflow: "hidden",
-};
-
-const mediaPreviewStyle: ImageStyle = {
-  width: "100%",
-  height: "100%",
-  borderRadius: 8,
-  backgroundColor: "#f0f0f0",
 };
 
 const mediaUploadIconStyle: ViewStyle = {
@@ -255,18 +235,6 @@ const modalScrollStyle: ViewStyle = {
   width: "100%",
 };
 
-const removeMediaButtonStyle: ViewStyle = {
-  alignItems: "center",
-  backgroundColor: "rgba(0,0,0,0.5)",
-  borderRadius: 12,
-  height: 18,
-  justifyContent: "center",
-  position: "absolute",
-  right: 8,
-  top: 8,
-  width: 18,
-};
-
 const scrollContentStyle: ViewStyle = {
   flexGrow: 1,
   justifyContent: "center",
@@ -295,16 +263,6 @@ const uploadButtonStyle: ViewStyle = {
   height: 56,
   justifyContent: "center",
   width: 56,
-};
-
-const videoIndicatorStyle: ViewStyle = {
-  position: "absolute",
-  top: "50%",
-  left: "50%",
-  transform: [{ translateX: -12 }, { translateY: -12 }],
-  backgroundColor: "rgba(0,0,0,0.5)",
-  borderRadius: 12,
-  padding: 4,
 };
 
 const uploadProgressContainerStyle: ViewStyle = {

--- a/src/components/DiscussFab.tsx
+++ b/src/components/DiscussFab.tsx
@@ -6,13 +6,11 @@ import {
   TextInput,
   KeyboardAvoidingView,
   Platform,
-  Image,
   ScrollView,
   Keyboard,
   KeyboardEvent,
   useWindowDimensions,
   ViewStyle,
-  ImageStyle,
   TextStyle,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -25,6 +23,7 @@ import { useLanguage } from "../contexts/LanguageContext";
 import { useMediaUpload } from "../hooks/useMediaUpload";
 import { captureEvent } from "../lib/posthog";
 import { POST_EVENTS } from "../constants/analyticsEvents";
+import { MediaGrid } from "./MediaGrid";
 
 interface DiscussFabProps {
   onPostCreated?: () => void;
@@ -67,6 +66,7 @@ const DiscussFab = ({ onPostCreated, bottomOffset = 16 }: DiscussFabProps) => {
 
   const {
     selectedMedia,
+    selectedMediaItems,
     setPostText,
     isSubmitting,
     uploadProgress,
@@ -169,29 +169,17 @@ const DiscussFab = ({ onPostCreated, bottomOffset = 16 }: DiscussFabProps) => {
                   </TouchableOpacity>
                 </View>
                 <View style={modalBodyStyle}>
-                  {selectedMedia ? (
-                    <View style={mediaPreviewContainerStyle}>
-                      <Image
-                        source={{
-                          uri: selectedMedia.isVideo
-                            ? selectedMedia.thumbnailUri || selectedMedia.previewUrl
-                            : selectedMedia.previewUrl,
-                        }}
-                        style={mediaPreviewStyle}
-                        resizeMode="contain"
-                      />
-                      <TouchableOpacity
-                        style={removeMediaButtonStyle}
-                        onPress={handleRemoveMedia}
-                      >
-                        <MaterialIcons name="close" size={12} color="white" />
-                      </TouchableOpacity>
-                      {selectedMedia.isVideo && (
-                        <View style={videoIndicatorStyle}>
-                          <MaterialIcons name="play-circle-filled" size={24} color="white" />
-                        </View>
-                      )}
-                    </View>
+                  {selectedMediaItems.length > 0 ? (
+                    <MediaGrid
+                      items={selectedMediaItems.map((item) => ({
+                        uri: item.thumbnailUri || item.previewUrl,
+                        isVideo: item.isVideo,
+                        useImageForVideo: true,
+                      }))}
+                      onRemove={handleRemoveMedia}
+                      height={210}
+                      style={mediaPreviewContainerStyle}
+                    />
                   ) : null}
 
                   <TextInput
@@ -212,20 +200,20 @@ const DiscussFab = ({ onPostCreated, bottomOffset = 16 }: DiscussFabProps) => {
                     <TouchableOpacity
                       style={[
                         mediaUploadButtonStyle,
-                        selectedMedia ? mediaUploadButtonDisabledStyle : null,
+                        selectedMediaItems.length >= 4 ? mediaUploadButtonDisabledStyle : null,
                       ]}
                       onPress={handleMediaUpload}
-                      disabled={!!selectedMedia}
+                      disabled={selectedMediaItems.length >= 4}
                     >
                       <MaterialIcons
                         name="add-photo-alternate"
                         size={20}
-                        color={selectedMedia ? colors.neutral.darkGrey : colors.light.primary}
+                        color={selectedMediaItems.length >= 4 ? colors.neutral.darkGrey : colors.light.primary}
                       />
                       <Text
                         style={[
                           mediaUploadTextStyle,
-                          selectedMedia ? mediaUploadTextDisabledStyle : null,
+                          selectedMediaItems.length >= 4 ? mediaUploadTextDisabledStyle : null,
                         ]}
                       >
                         {t("Add media")}
@@ -390,41 +378,8 @@ const closeIconStyle: TextStyle = {
 };
 
 const mediaPreviewContainerStyle: ViewStyle = {
-  position: "relative",
   width: "100%",
-  aspectRatio: 1.5,
-  borderRadius: 18,
   marginBottom: 14,
-  overflow: "hidden",
-};
-
-const mediaPreviewStyle: ImageStyle = {
-  width: "100%",
-  height: "100%",
-  borderRadius: 18,
-  backgroundColor: colors.light.accent3,
-};
-
-const removeMediaButtonStyle: ViewStyle = {
-  alignItems: "center",
-  backgroundColor: "rgba(0,0,0,0.5)",
-  borderRadius: 12,
-  height: 18,
-  justifyContent: "center",
-  position: "absolute",
-  right: 8,
-  top: 8,
-  width: 18,
-};
-
-const videoIndicatorStyle: ViewStyle = {
-  position: "absolute",
-  top: "50%",
-  left: "50%",
-  transform: [{ translateX: -12 }, { translateY: -12 }],
-  backgroundColor: "rgba(0,0,0,0.5)",
-  borderRadius: 12,
-  padding: 4,
 };
 
 const textInputStyle: TextStyle = {

--- a/src/components/DiscussFab.tsx
+++ b/src/components/DiscussFab.tsx
@@ -4,9 +4,7 @@ import {
   TouchableOpacity,
   Modal,
   TextInput,
-  KeyboardAvoidingView,
   Platform,
-  ScrollView,
   Keyboard,
   KeyboardEvent,
   useWindowDimensions,
@@ -37,8 +35,7 @@ const DiscussFab = ({ onPostCreated, bottomOffset = 16 }: DiscussFabProps) => {
   const { height: screenHeight } = useWindowDimensions();
   const [modalVisible, setModalVisible] = useState(false);
   const [keyboardVisible, setKeyboardVisible] = useState(false);
-  const keyboardVerticalOffset = Platform.OS === "ios" ? Math.max(insets.top - 12, 0) : 0;
-  const modalMaxHeight = Math.round(screenHeight * 0.5);
+  const [keyboardHeight, setKeyboardHeight] = useState(0);
 
   React.useEffect(() => {
     const syncKeyboardVisibility = (visible: boolean, event?: KeyboardEvent) => {
@@ -47,6 +44,7 @@ const DiscussFab = ({ onPostCreated, bottomOffset = 16 }: DiscussFabProps) => {
       }
 
       setKeyboardVisible(visible);
+      setKeyboardHeight(visible ? event?.endCoordinates?.height ?? 0 : 0);
     };
 
     const showSubscription = Keyboard.addListener(
@@ -85,6 +83,17 @@ const DiscussFab = ({ onPostCreated, bottomOffset = 16 }: DiscussFabProps) => {
     },
     successMessage: t("Post sent successfully!"),
   });
+  const modalTopPadding = insets.top + 12;
+  const modalBottomPadding = keyboardVisible ? keyboardHeight + 12 : insets.bottom + 12;
+  const availableModalHeight = Math.max(260, screenHeight - modalTopPadding - modalBottomPadding);
+  const modalHeight = Math.round(
+    Math.min(availableModalHeight, screenHeight * (keyboardVisible ? 0.92 : 0.78))
+  );
+  const modalHeaderHeight = 74;
+  const mediaPreviewHeight =
+    selectedMediaItems.length > 0
+      ? Math.max(120, Math.min(190, Math.floor((modalHeight - modalHeaderHeight - 88) / 2)))
+      : 0;
 
   const handleOpen = () => {
     setModalVisible(true);
@@ -125,130 +134,119 @@ const DiscussFab = ({ onPostCreated, bottomOffset = 16 }: DiscussFabProps) => {
         statusBarTranslucent
       >
         <View style={backdropStyle} />
-        <KeyboardAvoidingView
-          behavior={Platform.OS === "ios" ? "padding" : "height"}
-          style={keyboardViewStyle}
-          keyboardVerticalOffset={keyboardVerticalOffset}
+        <View
+          style={[
+            modalContainerStyle,
+            {
+              paddingTop: modalTopPadding,
+              paddingBottom: modalBottomPadding,
+              paddingHorizontal: "5%",
+            },
+          ]}
         >
-          <View
-            style={[
-              modalContainerStyle,
-              {
-                paddingTop: insets.top + 12,
-                paddingBottom: keyboardVisible ? 0 : insets.bottom + 12,
-                paddingHorizontal: "5%",
-              },
-            ]}
-          >
-            <ScrollView
-              style={modalScrollStyle}
-              contentContainerStyle={[
-                scrollContentStyle,
-                { justifyContent: keyboardVisible ? "flex-start" : "center" },
-              ]}
-              showsVerticalScrollIndicator={false}
-              keyboardShouldPersistTaps="handled"
-              keyboardDismissMode="on-drag"
-            >
-              <View style={[modalContentStyle, { maxHeight: modalMaxHeight }]}>
-                <View style={modalHeaderStyle}>
-                  <View style={headerGlowStyle} />
-                  <View style={headerRingStyle} />
-                  <View style={headerFillStyle} />
-                  <Text style={modalTitleStyle}>{t("Start a discussion")}</Text>
-                  <TouchableOpacity
-                    style={closeButtonStyle}
-                    onPress={() => setModalVisible(false)}
-                  >
-                    <MaterialIcons
-                      name="close"
-                      size={20}
-                      color={colors.light.text}
-                      style={closeIconStyle}
-                    />
-                  </TouchableOpacity>
-                </View>
-                <View style={modalBodyStyle}>
-                  {selectedMediaItems.length > 0 ? (
-                    <MediaGrid
-                      items={selectedMediaItems.map((item) => ({
-                        uri: item.thumbnailUri || item.previewUrl,
-                        isVideo: item.isVideo,
-                        useImageForVideo: true,
-                      }))}
-                      onRemove={handleRemoveMedia}
-                      height={210}
-                      style={mediaPreviewContainerStyle}
-                    />
-                  ) : null}
+          <View style={[modalContentStyle, { height: modalHeight }]}>
+            <View style={modalHeaderStyle}>
+              <View style={headerGlowStyle} />
+              <View style={headerRingStyle} />
+              <View style={headerFillStyle} />
+              <Text style={modalTitleStyle}>{t("Start a discussion")}</Text>
+              <TouchableOpacity
+                style={closeButtonStyle}
+                onPress={() => setModalVisible(false)}
+              >
+                <MaterialIcons
+                  name="close"
+                  size={20}
+                  color={colors.light.text}
+                  style={closeIconStyle}
+                />
+              </TouchableOpacity>
+            </View>
+            <View style={modalBodyStyle}>
+              {selectedMediaItems.length > 0 ? (
+                <MediaGrid
+                  items={selectedMediaItems.map((item) => ({
+                    uri: item.thumbnailUri || item.previewUrl,
+                    isVideo: item.isVideo,
+                    useImageForVideo: true,
+                  }))}
+                  onRemove={handleRemoveMedia}
+                  height={mediaPreviewHeight}
+                  style={mediaPreviewContainerStyle}
+                />
+              ) : null}
 
-                  <TextInput
-                    style={textInputStyle}
-                    multiline
-                    scrollEnabled
-                    textAlignVertical="top"
-                    autoFocus
-                    placeholder={t(
-                      "Share your thoughts, start a discussion, or share an achievement..."
-                    )}
-                    placeholderTextColor="#999"
-                    maxLength={1000}
-                    onChangeText={setPostText}
+              <TextInput
+                style={[
+                  textInputStyle,
+                  selectedMediaItems.length > 0
+                    ? textInputWithMediaStyle
+                    : textInputWithoutMediaStyle,
+                ]}
+                multiline
+                scrollEnabled
+                textAlignVertical="top"
+                autoFocus
+                placeholder={t(
+                  "Share your thoughts, start a discussion, or share an achievement..."
+                )}
+                placeholderTextColor="#999"
+                maxLength={1000}
+                onChangeText={setPostText}
+              />
+            </View>
+            <View style={modalFooterStyle}>
+              <View style={mediaUploadContainerStyle}>
+                <TouchableOpacity
+                  style={[
+                    mediaUploadButtonStyle,
+                    selectedMediaItems.length >= 4 ? mediaUploadButtonDisabledStyle : null,
+                  ]}
+                  onPress={handleMediaUpload}
+                  disabled={selectedMediaItems.length >= 4}
+                >
+                  <MaterialIcons
+                    name="add-photo-alternate"
+                    size={20}
+                    color={selectedMediaItems.length >= 4 ? colors.neutral.darkGrey : colors.light.primary}
                   />
+                  <Text
+                    style={[
+                      mediaUploadTextStyle,
+                      selectedMediaItems.length >= 4 ? mediaUploadTextDisabledStyle : null,
+                    ]}
+                  >
+                    {t("Add media")}
+                  </Text>
+                </TouchableOpacity>
 
-                  <View style={mediaUploadContainerStyle}>
-                    <TouchableOpacity
-                      style={[
-                        mediaUploadButtonStyle,
-                        selectedMediaItems.length >= 4 ? mediaUploadButtonDisabledStyle : null,
-                      ]}
-                      onPress={handleMediaUpload}
-                      disabled={selectedMediaItems.length >= 4}
-                    >
-                      <MaterialIcons
-                        name="add-photo-alternate"
-                        size={20}
-                        color={selectedMediaItems.length >= 4 ? colors.neutral.darkGrey : colors.light.primary}
-                      />
-                      <Text
-                        style={[
-                          mediaUploadTextStyle,
-                          selectedMediaItems.length >= 4 ? mediaUploadTextDisabledStyle : null,
-                        ]}
-                      >
-                        {t("Add media")}
-                      </Text>
-                    </TouchableOpacity>
+                <FeatureActionButton
+                  disabled={isSubmitting}
+                  fullWidth={false}
+                  onPress={onSubmit}
+                  showIcon={false}
+                  style={submitButtonStyle}
+                  title={t(isSubmitting ? "Submitting..." : "Submit")}
+                  tone="indigo"
+                  variant="pill"
+                />
+              </View>
 
-                    <FeatureActionButton
-                      disabled={isSubmitting}
-                      fullWidth={false}
-                      onPress={onSubmit}
-                      showIcon={false}
-                      style={submitButtonStyle}
-                      title={t(isSubmitting ? "Submitting..." : "Submit")}
-                      tone="indigo"
-                      variant="pill"
+              {uploadProgress !== null && (
+                <View style={uploadProgressContainerStyle}>
+                  <Text style={uploadProgressTextStyle}>
+                    {t("Uploading media...")} {Math.round(uploadProgress)}%
+                  </Text>
+                  <View style={progressBarContainerStyle}>
+                    <View
+                      style={[progressBarFillStyle, { width: `${uploadProgress}%` }]}
                     />
                   </View>
-
-                  {uploadProgress !== null && (
-                    <View style={uploadProgressContainerStyle}>
-                      <Text style={uploadProgressTextStyle}>
-                        {t("Uploading media...")} {Math.round(uploadProgress)}%
-                      </Text>
-                      <View style={progressBarContainerStyle}>
-                        <View
-                          style={[progressBarFillStyle, { width: `${uploadProgress}%` }]}
-                        />
-                      </View>
-                    </View>
-                  )}
                 </View>
-              </View>
-            </ScrollView>
+              )}
+            </View>
           </View>
-        </KeyboardAvoidingView>
+        </View>
       </Modal>
     </>
   );
@@ -264,10 +262,6 @@ const fabStyle: ViewStyle = {
   elevation: 6,
 };
 
-const keyboardViewStyle: ViewStyle = {
-  flex: 1,
-};
-
 const backdropStyle: ViewStyle = {
   backgroundColor: "rgba(0,0,0,0.5)",
   bottom: 0,
@@ -280,15 +274,7 @@ const backdropStyle: ViewStyle = {
 const modalContainerStyle: ViewStyle = {
   alignItems: "center",
   flex: 1,
-};
-
-const modalScrollStyle: ViewStyle = {
-  flex: 1,
-  width: "100%",
-};
-
-const scrollContentStyle: ViewStyle = {
-  flexGrow: 1,
+  justifyContent: "flex-end",
 };
 
 const modalContentStyle: ViewStyle = {
@@ -296,7 +282,6 @@ const modalContentStyle: ViewStyle = {
   borderColor: colors.light.accent2,
   borderRadius: 26,
   borderWidth: 1,
-  flex: 1,
   overflow: "hidden",
   padding: 0,
   shadowColor: "#000",
@@ -387,7 +372,6 @@ const textInputStyle: TextStyle = {
   borderColor: colors.light.accent2,
   borderRadius: 18,
   borderWidth: 1,
-  flex: 1,
   marginBottom: 6,
   minHeight: 120,
   paddingHorizontal: 14,
@@ -470,6 +454,26 @@ const progressBarFillStyle: ViewStyle = {
 const modalBodyStyle: ViewStyle = {
   flex: 1,
   padding: 20,
+  width: "100%",
+};
+
+const textInputWithMediaStyle: TextStyle = {
+  flex: 1,
+  marginBottom: 0,
+};
+
+const textInputWithoutMediaStyle: TextStyle = {
+  flex: 1,
+  marginBottom: 0,
+};
+
+const modalFooterStyle: ViewStyle = {
+  backgroundColor: "white",
+  borderTopColor: colors.light.accent2,
+  borderTopWidth: 1,
+  paddingHorizontal: 20,
+  paddingTop: 14,
+  paddingBottom: 20,
 };
 
 export default DiscussFab;

--- a/src/components/InlineCreatePost.tsx
+++ b/src/components/InlineCreatePost.tsx
@@ -3,12 +3,9 @@ import {
   View,
   TextInput,
   TouchableOpacity,
-  Image,
   ViewStyle,
   TextStyle,
-  ImageStyle,
   Modal,
-  Pressable,
 } from "react-native";
 import { colors } from "../constants/Colors";
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
@@ -18,6 +15,7 @@ import { useLanguage } from "../contexts/LanguageContext";
 import { Loader } from "./Loader";
 import { useMediaUpload } from "../hooks/useMediaUpload";
 import ImageViewer from "react-native-image-zoom-viewer";
+import { MediaGrid } from "./MediaGrid";
 
 const POST_PROMPT_KEYS = [
   "What made you step outside your comfort zone today?",
@@ -54,6 +52,7 @@ const InlineCreatePost = ({ onPostCreated, refreshKey = 0 }: InlineCreatePostPro
 
   const {
     selectedMedia,
+    selectedMediaItems,
     isUploading,
     handleMediaUpload,
     handleRemoveMedia,
@@ -84,7 +83,7 @@ const InlineCreatePost = ({ onPostCreated, refreshKey = 0 }: InlineCreatePostPro
     setPostText(text);
   };
 
-  const hasContent = inputText.trim().length > 0 || selectedMedia;
+  const hasContent = inputText.trim().length > 0 || selectedMediaItems.length > 0;
 
   return (
     <View style={containerStyle}>
@@ -93,26 +92,18 @@ const InlineCreatePost = ({ onPostCreated, refreshKey = 0 }: InlineCreatePostPro
         <View style={mediaPreviewContainerStyle}>
           <Loader />
         </View>
-      ) : selectedMedia ? (
-        <Pressable style={mediaPreviewContainerStyle} onPress={() => setShowFullScreenImage(true)}>
-          <Image
-            source={{
-              uri: selectedMedia.isVideo
-                ? selectedMedia.thumbnailUri || selectedMedia.previewUrl
-                : selectedMedia.previewUrl,
-            }}
-            style={mediaPreviewStyle}
-            resizeMode="cover"
-          />
-          <TouchableOpacity style={removeMediaButtonStyle} onPress={handleRemoveMedia}>
-            <MaterialIcons name="close" size={12} color="white" />
-          </TouchableOpacity>
-          {selectedMedia.isVideo && (
-            <View style={videoIndicatorStyle}>
-              <MaterialIcons name="play-circle-filled" size={20} color="white" />
-            </View>
-          )}
-        </Pressable>
+      ) : selectedMediaItems.length > 0 ? (
+        <MediaGrid
+          items={selectedMediaItems.map((item) => ({
+            uri: item.thumbnailUri || item.previewUrl,
+            isVideo: item.isVideo,
+            useImageForVideo: true,
+          }))}
+          onPress={() => setShowFullScreenImage(true)}
+          onRemove={handleRemoveMedia}
+          height={160}
+          style={mediaPreviewContainerStyle}
+        />
       ) : null}
 
       {/* Input row */}
@@ -220,41 +211,8 @@ const mediaButtonStyle: ViewStyle = {
 
 
 const mediaPreviewContainerStyle: ViewStyle = {
-  position: "relative",
   width: "100%",
-  height: 100,
-  borderRadius: 8,
   marginBottom: 8,
-  overflow: "hidden",
-  backgroundColor: colors.neutral.grey2,
-};
-
-const mediaPreviewStyle: ImageStyle = {
-  width: "100%",
-  height: "100%",
-  borderRadius: 8,
-};
-
-const removeMediaButtonStyle: ViewStyle = {
-  alignItems: "center",
-  backgroundColor: "rgba(0,0,0,0.6)",
-  borderRadius: 10,
-  height: 20,
-  justifyContent: "center",
-  position: "absolute",
-  right: 6,
-  top: 6,
-  width: 20,
-};
-
-const videoIndicatorStyle: ViewStyle = {
-  position: "absolute",
-  top: "50%",
-  left: "50%",
-  transform: [{ translateX: -10 }, { translateY: -10 }],
-  backgroundColor: "rgba(0,0,0,0.5)",
-  borderRadius: 10,
-  padding: 2,
 };
 
 const fullScreenContainerStyle: ViewStyle = {
@@ -271,4 +229,3 @@ const closeFullScreenButtonStyle: ViewStyle = {
 };
 
 export default InlineCreatePost;
-

--- a/src/components/InlineCreatePost.tsx
+++ b/src/components/InlineCreatePost.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from "react";
+import React, { useEffect, useState } from "react";
 import {
   View,
   TextInput,
@@ -38,20 +38,23 @@ const InlineCreatePost = ({ onPostCreated, refreshKey = 0 }: InlineCreatePostPro
   const { user } = useAuth();
   const { t } = useLanguage();
   const [inputText, setInputText] = useState("");
-  
-  // Pick a random prompt when refreshKey changes
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const placeholderKey = useMemo(() => {
+
+  const [placeholderKey, setPlaceholderKey] = useState(() => {
     const randomIndex = Math.floor(Math.random() * POST_PROMPT_KEYS.length);
     return POST_PROMPT_KEYS[randomIndex];
+  });
+
+  useEffect(() => {
+    const randomIndex = Math.floor(Math.random() * POST_PROMPT_KEYS.length);
+    setPlaceholderKey(POST_PROMPT_KEYS[randomIndex]);
   }, [refreshKey]);
-  
+
   const placeholder = t(placeholderKey);
   const [isFocused, setIsFocused] = useState(false);
   const [showFullScreenImage, setShowFullScreenImage] = useState(false);
+  const [selectedPreviewIndex, setSelectedPreviewIndex] = useState(0);
 
   const {
-    selectedMedia,
     selectedMediaItems,
     isUploading,
     handleMediaUpload,
@@ -99,7 +102,10 @@ const InlineCreatePost = ({ onPostCreated, refreshKey = 0 }: InlineCreatePostPro
             isVideo: item.isVideo,
             useImageForVideo: true,
           }))}
-          onPress={() => setShowFullScreenImage(true)}
+          onPress={(index) => {
+            setSelectedPreviewIndex(index);
+            setShowFullScreenImage(true);
+          }}
           onRemove={handleRemoveMedia}
           height={160}
           style={mediaPreviewContainerStyle}
@@ -150,7 +156,8 @@ const InlineCreatePost = ({ onPostCreated, refreshKey = 0 }: InlineCreatePostPro
             <MaterialIcons name="close" size={28} color="white" />
           </TouchableOpacity>
           <ImageViewer
-            imageUrls={[{ url: selectedMedia?.previewUrl || "" }]}
+            imageUrls={selectedMediaItems.map((item) => ({ url: item.thumbnailUri || item.previewUrl }))}
+            index={selectedPreviewIndex}
             enableSwipeDown
             onSwipeDown={() => setShowFullScreenImage(false)}
             renderIndicator={() => <></>}

--- a/src/components/MediaGrid.tsx
+++ b/src/components/MediaGrid.tsx
@@ -1,0 +1,167 @@
+import React from "react";
+import { Pressable, StyleSheet, TouchableOpacity, View, ViewStyle } from "react-native";
+import MaterialIcons from "@expo/vector-icons/MaterialIcons";
+import { Image } from "expo-image";
+import { ResizeMode, Video } from "expo-av";
+import { colors } from "../constants/Colors";
+
+export interface MediaGridItem {
+  uri: string;
+  isVideo?: boolean;
+  useImageForVideo?: boolean;
+}
+
+interface MediaGridProps {
+  items: MediaGridItem[];
+  onPress?: (index: number) => void;
+  onRemove?: (index: number) => void;
+  height?: number;
+  style?: ViewStyle;
+}
+
+export const MediaGrid: React.FC<MediaGridProps> = ({
+  items,
+  onPress,
+  onRemove,
+  height = 260,
+  style,
+}) => {
+  const visibleItems = items.slice(0, 4);
+  if (visibleItems.length === 0) return null;
+
+  const renderTile = (item: MediaGridItem, index: number, tileStyle: ViewStyle) => (
+    <Pressable
+      key={`${item.uri}-${index}`}
+      onPress={() => onPress?.(index)}
+      style={[styles.tile, tileStyle]}
+    >
+      {item.isVideo && !item.useImageForVideo ? (
+        <Video
+          source={{ uri: item.uri }}
+          style={styles.image}
+          resizeMode={ResizeMode.COVER}
+          shouldPlay={false}
+          isMuted
+          useNativeControls={false}
+        />
+      ) : (
+        <Image source={{ uri: item.uri }} style={styles.image} contentFit="cover" cachePolicy="memory-disk" />
+      )}
+      {item.isVideo && (
+        <View style={styles.videoOverlay}>
+          <MaterialIcons name="play-circle-filled" size={30} color="white" />
+        </View>
+      )}
+      {onRemove && (
+        <TouchableOpacity style={styles.removeButton} onPress={() => onRemove(index)}>
+          <MaterialIcons name="close" size={14} color="white" />
+        </TouchableOpacity>
+      )}
+    </Pressable>
+  );
+
+  if (visibleItems.length === 1) {
+    return (
+      <View style={[styles.container, { height }, style]}>
+        {renderTile(visibleItems[0], 0, styles.fullTile)}
+      </View>
+    );
+  }
+
+  if (visibleItems.length === 2) {
+    return (
+      <View style={[styles.container, styles.row, { height }, style]}>
+        {visibleItems.map((item, index) => renderTile(item, index, styles.halfTile))}
+      </View>
+    );
+  }
+
+  if (visibleItems.length === 3) {
+    return (
+      <View style={[styles.container, styles.row, { height }, style]}>
+        {renderTile(visibleItems[0], 0, styles.halfTile)}
+        <View style={styles.column}>
+          {visibleItems.slice(1).map((item, offset) =>
+            renderTile(item, offset + 1, styles.stackedTile)
+          )}
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <View style={[styles.container, { height }, style]}>
+      <View style={styles.gridRow}>
+        {visibleItems.slice(0, 2).map((item, index) => renderTile(item, index, styles.gridTile))}
+      </View>
+      <View style={styles.gridRow}>
+        {visibleItems.slice(2, 4).map((item, index) =>
+          renderTile(item, index + 2, styles.gridTile)
+        )}
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  column: {
+    flex: 1,
+    gap: 2,
+  },
+  container: {
+    borderRadius: 8,
+    gap: 2,
+    overflow: "hidden",
+    width: "100%",
+  },
+  fullTile: {
+    flex: 1,
+  },
+  gridRow: {
+    flex: 1,
+    flexDirection: "row",
+    gap: 2,
+  },
+  gridTile: {
+    flex: 1,
+  },
+  halfTile: {
+    flex: 1,
+  },
+  image: {
+    height: "100%",
+    width: "100%",
+  },
+  removeButton: {
+    alignItems: "center",
+    backgroundColor: "rgba(0,0,0,0.65)",
+    borderRadius: 11,
+    height: 22,
+    justifyContent: "center",
+    position: "absolute",
+    right: 6,
+    top: 6,
+    width: 22,
+  },
+  row: {
+    flexDirection: "row",
+  },
+  stackedTile: {
+    flex: 1,
+  },
+  tile: {
+    backgroundColor: colors.neutral.grey2,
+    overflow: "hidden",
+    position: "relative",
+  },
+  videoOverlay: {
+    alignItems: "center",
+    backgroundColor: "rgba(0,0,0,0.28)",
+    bottom: 0,
+    justifyContent: "center",
+    left: 0,
+    position: "absolute",
+    right: 0,
+    top: 0,
+  },
+});

--- a/src/components/MediaGrid.tsx
+++ b/src/components/MediaGrid.tsx
@@ -1,9 +1,11 @@
-import React from "react";
-import { Pressable, StyleSheet, TouchableOpacity, View, ViewStyle } from "react-native";
+import React, { useState } from "react";
+import { Pressable, StyleProp, StyleSheet, TouchableOpacity, View, ViewStyle } from "react-native";
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
-import { Image } from "expo-image";
+import { Image, ImageLoadEventData } from "expo-image";
 import { ResizeMode, Video } from "expo-av";
 import { colors } from "../constants/Colors";
+
+const TILE_GAP = 3;
 
 export interface MediaGridItem {
   uri: string;
@@ -16,7 +18,7 @@ interface MediaGridProps {
   onPress?: (index: number) => void;
   onRemove?: (index: number) => void;
   height?: number;
-  style?: ViewStyle;
+  style?: StyleProp<ViewStyle>;
 }
 
 export const MediaGrid: React.FC<MediaGridProps> = ({
@@ -27,9 +29,34 @@ export const MediaGrid: React.FC<MediaGridProps> = ({
   style,
 }) => {
   const visibleItems = items.slice(0, 4);
+  const [containerWidth, setContainerWidth] = useState(0);
+  const [singleImageRatio, setSingleImageRatio] = useState<number | null>(null);
   if (visibleItems.length === 0) return null;
 
-  const renderTile = (item: MediaGridItem, index: number, tileStyle: ViewStyle) => (
+  const singleItem = visibleItems.length === 1 ? visibleItems[0] : null;
+  const singleImageHeight =
+    singleItem && !singleItem.isVideo && singleImageRatio && containerWidth > 0
+      ? Math.min(height, containerWidth / singleImageRatio)
+      : height;
+  const sizeStyle: ViewStyle = {
+    aspectRatio: undefined,
+    height: singleImageHeight,
+    width: "100%",
+  };
+  const fixedGridSizeStyle: ViewStyle = {
+    aspectRatio: undefined,
+    height,
+    width: "100%",
+  };
+
+  const handleSingleImageLoad = (event: ImageLoadEventData) => {
+    const { width, height: imageHeight } = event.source;
+    if (width > 0 && imageHeight > 0) {
+      setSingleImageRatio(width / imageHeight);
+    }
+  };
+
+  const renderTile = (item: MediaGridItem, index: number, tileStyle: StyleProp<ViewStyle>) => (
     <Pressable
       key={`${item.uri}-${index}`}
       onPress={() => onPress?.(index)}
@@ -45,7 +72,13 @@ export const MediaGrid: React.FC<MediaGridProps> = ({
           useNativeControls={false}
         />
       ) : (
-        <Image source={{ uri: item.uri }} style={styles.image} contentFit="cover" cachePolicy="memory-disk" />
+        <Image
+          source={{ uri: item.uri }}
+          style={styles.image}
+          contentFit="cover"
+          cachePolicy="memory-disk"
+          onLoad={visibleItems.length === 1 && !item.isVideo ? handleSingleImageLoad : undefined}
+        />
       )}
       {item.isVideo && (
         <View style={styles.videoOverlay}>
@@ -62,7 +95,10 @@ export const MediaGrid: React.FC<MediaGridProps> = ({
 
   if (visibleItems.length === 1) {
     return (
-      <View style={[styles.container, { height }, style]}>
+      <View
+        onLayout={(event) => setContainerWidth(event.nativeEvent.layout.width)}
+        style={[styles.container, style, sizeStyle]}
+      >
         {renderTile(visibleItems[0], 0, styles.fullTile)}
       </View>
     );
@@ -70,19 +106,24 @@ export const MediaGrid: React.FC<MediaGridProps> = ({
 
   if (visibleItems.length === 2) {
     return (
-      <View style={[styles.container, styles.row, { height }, style]}>
-        {visibleItems.map((item, index) => renderTile(item, index, styles.halfTile))}
+      <View style={[styles.container, style, styles.row, fixedGridSizeStyle]}>
+        {visibleItems.map((item, index) =>
+          renderTile(item, index, [styles.halfTile, index === 0 ? styles.rightGap : null])
+        )}
       </View>
     );
   }
 
   if (visibleItems.length === 3) {
     return (
-      <View style={[styles.container, styles.row, { height }, style]}>
-        {renderTile(visibleItems[0], 0, styles.halfTile)}
+      <View style={[styles.container, style, styles.row, fixedGridSizeStyle]}>
+        {renderTile(visibleItems[0], 0, [styles.halfTile, styles.rightGap])}
         <View style={styles.column}>
           {visibleItems.slice(1).map((item, offset) =>
-            renderTile(item, offset + 1, styles.stackedTile)
+            renderTile(item, offset + 1, [
+              styles.stackedTile,
+              offset === 0 ? styles.bottomGap : null,
+            ])
           )}
         </View>
       </View>
@@ -90,13 +131,15 @@ export const MediaGrid: React.FC<MediaGridProps> = ({
   }
 
   return (
-    <View style={[styles.container, { height }, style]}>
-      <View style={styles.gridRow}>
-        {visibleItems.slice(0, 2).map((item, index) => renderTile(item, index, styles.gridTile))}
+    <View style={[styles.container, style, fixedGridSizeStyle]}>
+      <View style={[styles.gridRow, styles.bottomGap]}>
+        {visibleItems.slice(0, 2).map((item, index) =>
+          renderTile(item, index, [styles.gridTile, index === 0 ? styles.rightGap : null])
+        )}
       </View>
       <View style={styles.gridRow}>
         {visibleItems.slice(2, 4).map((item, index) =>
-          renderTile(item, index + 2, styles.gridTile)
+          renderTile(item, index + 2, [styles.gridTile, index === 0 ? styles.rightGap : null])
         )}
       </View>
     </View>
@@ -106,13 +149,13 @@ export const MediaGrid: React.FC<MediaGridProps> = ({
 const styles = StyleSheet.create({
   column: {
     flex: 1,
-    gap: 2,
   },
   container: {
     borderRadius: 8,
-    gap: 2,
-    overflow: "hidden",
     width: "100%",
+  },
+  bottomGap: {
+    marginBottom: TILE_GAP,
   },
   fullTile: {
     flex: 1,
@@ -120,7 +163,6 @@ const styles = StyleSheet.create({
   gridRow: {
     flex: 1,
     flexDirection: "row",
-    gap: 2,
   },
   gridTile: {
     flex: 1,
@@ -143,6 +185,9 @@ const styles = StyleSheet.create({
     top: 6,
     width: 22,
   },
+  rightGap: {
+    marginRight: TILE_GAP,
+  },
   row: {
     flexDirection: "row",
   },
@@ -151,6 +196,9 @@ const styles = StyleSheet.create({
   },
   tile: {
     backgroundColor: colors.neutral.grey2,
+    borderColor: colors.neutral.grey2,
+    borderRadius: 8,
+    borderWidth: 1,
     overflow: "hidden",
     position: "relative",
   },

--- a/src/components/NotificationSidebar.tsx
+++ b/src/components/NotificationSidebar.tsx
@@ -121,8 +121,9 @@ const NotificationSidebar: React.FC<NotificationSidebarProps> = ({ visible, onCl
     } else if (item.action_type === 'like') {
       notificationText = item.comment_id ? t('liked your comment') : t('liked your post');
     } else if (item.action_type === 'comment') {
-      const commentText = item.comment?.body || '';
-      notificationText = t('commented: "(comment)"', { comment: commentText });
+      const commentText = item.comment?.body?.trim() || '';
+      const previewText = commentText || (item.comment?.media_id ? '🖼️' : '');
+      notificationText = t('commented: "(comment)"', { comment: previewText });
     }
 
     const handlePress = () => {

--- a/src/components/Post.tsx
+++ b/src/components/Post.tsx
@@ -18,6 +18,7 @@ import {
 } from "react-native";
 import MaterialCommunityIcons from "react-native-vector-icons/MaterialCommunityIcons";
 import { Ionicons } from "@expo/vector-icons";
+import MaterialIcons from "@expo/vector-icons/MaterialIcons";
 import { MenuProvider } from "react-native-popup-menu";
 import { AnimatedSendButton } from "./AnimatedSendButton";
 import CommentPreviewRow from "./CommentPreviewRow";
@@ -50,6 +51,7 @@ import { useInstagramShare } from "../hooks/useInstagramShare";
 import { usePostDeleteCleanup } from "../hooks/usePostDeleteCleanup";
 import InstagramStoryCard from "./InstagramStoryCard";
 import { MediaGrid } from "./MediaGrid";
+import { useMediaSelection } from "../hooks/useMediaSelection";
 
 interface PostProps {
   post: PostType;
@@ -103,6 +105,13 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
   const [showVideoModal, setShowVideoModal] = useState(false);
   const [inlineComment, setInlineComment] = useState("");
   const [localPreviews, setLocalPreviews] = useState(post.comment_previews || []);
+  const {
+    selectedMediaItems: inlineCommentMediaItems,
+    isUploading: isInlineCommentMediaUploading,
+    handleMediaUpload: handleInlineCommentMediaUpload,
+    handleRemoveMedia: handleRemoveInlineCommentMedia,
+    clearMedia: clearInlineCommentMedia,
+  } = useMediaSelection();
   const lastTapTime = useRef<number>(0);
   const singleTapTimer = useRef<number | null>(null);
   const heartScale = useRef(new Animated.Value(0)).current;
@@ -289,18 +298,25 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
   };
 
   const handleInlineComment = async () => {
-    if (!inlineComment.trim() || !user) return;
+    if ((!inlineComment.trim() && inlineCommentMediaItems.length === 0) || !user) return;
 
     const commentText = inlineComment.trim();
     setInlineComment("");
 
     try {
-      const newComment = await addCommentMutation(user.id, commentText);
+      const newComment = await addCommentMutation(
+        user.id,
+        commentText,
+        null,
+        inlineCommentMediaItems
+      );
       if (newComment) {
+        clearInlineCommentMedia();
         setCommentCount(prev => prev + 1);
         setLocalPreviews(prev => [...prev, {
           username: currentUserUsername || "unknown",
           text: commentText,
+          has_media: inlineCommentMediaItems.length > 0,
         }]);
 
         if (user.id !== post.user_id) {
@@ -309,7 +325,7 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
             user.user_metadata?.username,
             post.user_id,
             post.id.toString(),
-            commentText,
+            commentText || "🖼️",
             newComment.id.toString(),
             {
               title: t("(username) commented"),
@@ -323,6 +339,7 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
           comment_id: newComment.id,
           comment_length: commentText.length,
           source: "inline",
+          media_count: inlineCommentMediaItems.length,
         });
       }
     } catch (error) {
@@ -707,6 +724,7 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
                   username={preview.username}
                   text={preview.text}
                   replyToUsername={preview.replyToUsername}
+                  hasMedia={preview.has_media}
                   isLast={isLast}
                 />
               );
@@ -722,6 +740,29 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
         )}
 
         <View style={inlineCommentContainer}>
+          {inlineCommentMediaItems.length > 0 ? (
+            <MediaGrid
+              items={inlineCommentMediaItems.map((item) => ({
+                uri: item.thumbnailUri || item.previewUrl,
+                isVideo: item.isVideo,
+                useImageForVideo: true,
+              }))}
+              onRemove={handleRemoveInlineCommentMedia}
+              height={120}
+              style={inlineCommentMediaPreviewStyle}
+            />
+          ) : null}
+          <View style={inlineCommentRowStyle}>
+            <TouchableOpacity
+              onPress={handleInlineCommentMediaUpload}
+              disabled={inlineCommentMediaItems.length >= 4 || isInlineCommentMediaUploading || isAddingComment}
+              style={[
+                inlineCommentMediaButtonStyle,
+                (inlineCommentMediaItems.length >= 4 || isInlineCommentMediaUploading) ? inlineCommentMediaButtonDisabledStyle : null,
+              ]}
+            >
+              <MaterialIcons name="add-photo-alternate" size={18} color={colors.light.primary} />
+            </TouchableOpacity>
           <TextInput
             style={inlineCommentInput}
             placeholder={t("Add a comment...")}
@@ -734,11 +775,12 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
             textAlignVertical="top"
           />
           <AnimatedSendButton
-            hasContent={inlineComment.trim().length > 0}
+            hasContent={inlineComment.trim().length > 0 || inlineCommentMediaItems.length > 0}
             onPress={handleInlineComment}
-            disabled={isAddingComment}
+            disabled={isAddingComment || isInlineCommentMediaUploading}
             size="small"
           />
+          </View>
         </View>
 
         <Modal
@@ -979,16 +1021,34 @@ const viewAllCommentsStyle: TextStyle = {
 };
 
 const inlineCommentContainer: ViewStyle = {
-  flexDirection: "row",
-  alignItems: "flex-end",
   marginTop: 6,
   paddingHorizontal: 8,
-  gap: 4,
   paddingVertical: 6,
   backgroundColor: colors.neutral.white,
   borderRadius: 8,
   borderWidth: 1,
   borderColor: colors.neutral.grey2,
+};
+
+const inlineCommentRowStyle: ViewStyle = {
+  flexDirection: "row",
+  alignItems: "center",
+  gap: 4,
+};
+
+const inlineCommentMediaPreviewStyle: ViewStyle = {
+  marginBottom: 8,
+  width: "100%",
+};
+
+const inlineCommentMediaButtonStyle: ViewStyle = {
+  alignItems: "center",
+  justifyContent: "center",
+  paddingHorizontal: 2,
+};
+
+const inlineCommentMediaButtonDisabledStyle: ViewStyle = {
+  opacity: 0.45,
 };
 
 const inlineCommentInput: TextStyle = {

--- a/src/components/Post.tsx
+++ b/src/components/Post.tsx
@@ -49,6 +49,7 @@ import { translationService } from "../services/translationService";
 import { useInstagramShare } from "../hooks/useInstagramShare";
 import { usePostDeleteCleanup } from "../hooks/usePostDeleteCleanup";
 import InstagramStoryCard from "./InstagramStoryCard";
+import { MediaGrid } from "./MediaGrid";
 
 interface PostProps {
   post: PostType;
@@ -89,6 +90,8 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
   const [isTranslating, setIsTranslating] = useState(false);
   const [commentCount, setCommentCount] = useState(post.comments_count || 0);
   const [showFullScreenImage, setShowFullScreenImage] = useState(false);
+  const [selectedMediaIndex, setSelectedMediaIndex] = useState(0);
+  const [selectedImageViewerIndex, setSelectedImageViewerIndex] = useState(0);
   const {
     comments: commentList,
     loading: commentsLoading,
@@ -104,11 +107,11 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
   const singleTapTimer = useRef<number | null>(null);
   const heartScale = useRef(new Animated.Value(0)).current;
   const heartOpacity = useRef(new Animated.Value(0)).current;
-  const { storyCardRef, isSharing, onImageLoad, completionCount, shareToInstagram } = useInstagramShare({
+  const { storyCardRef, isSharing, completionCount, shareToInstagram } = useInstagramShare({
     postId: post.id,
     isChallengePost: !!post.challenge_id,
-    challengeId: post.challenge_id,
-    mediaUrl: post.media?.file_path,
+    challengeId: post.challenge_id ?? undefined,
+    mediaUrl: post.media?.file_path ?? undefined,
   });
 
   useEffect(() => {
@@ -180,6 +183,13 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
     return source.match(/\.(mp4|mov|avi|wmv)$/i);
   };
 
+  const mediaItems = (post.media_items && post.media_items.length > 0)
+    ? post.media_items
+    : post.media?.file_path
+      ? [{ media_id: post.media_id || 0, file_path: post.media.file_path, position: 0 }]
+      : [];
+  const imageViewerItems = mediaItems.filter((item) => item.file_path && !isVideo(item.file_path));
+
   const showHeartAnimation = () => {
     // Reset animation values
     heartScale.setValue(0);
@@ -221,7 +231,7 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
     ]).start();
   };
 
-  const handleDoubleTap = () => {
+  const handleDoubleTap = (mediaIndex = 0) => {
     const now = Date.now();
     const DOUBLE_PRESS_DELAY = 300;
 
@@ -239,14 +249,21 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
       lastTapTime.current = now;
       singleTapTimer.current = setTimeout(() => {
         // Single tap - open fullscreen/modal only if there's media
-        if (post.media?.file_path) {
-          if (isVideo(post.media.file_path)) {
+        const mediaItem = mediaItems[mediaIndex];
+        if (mediaItem?.file_path) {
+          setSelectedMediaIndex(mediaIndex);
+          if (isVideo(mediaItem.file_path)) {
             setShowVideoModal(true);
             captureEvent(POST_EVENTS.VIDEO_PLAYED, {
               post_id: post.id,
               is_challenge_post: !!post.challenge_id,
             });
           } else {
+            const imageIndex = mediaItems
+              .slice(0, mediaIndex)
+              .filter((item) => item.file_path && !isVideo(item.file_path))
+              .length;
+            setSelectedImageViewerIndex(imageIndex);
             setShowFullScreenImage(true);
             captureEvent(POST_EVENTS.MEDIA_VIEWED, {
               post_id: post.id,
@@ -345,7 +362,8 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
 
   const handleImageLongPress = async () => {
     try {
-      const urls = await imageService.getPostImageUrl(post.media?.file_path || "", "original");
+      const selectedImage = imageViewerItems[selectedImageViewerIndex];
+      const urls = await imageService.getPostImageUrl(selectedImage?.file_path || "", "original");
 
       // Download the image first
       const response = await fetch(urls.fullUrl);
@@ -379,26 +397,26 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
   };
 
   const renderMedia = () => {
-    if (!post.media?.file_path) return null;
+    if (mediaItems.length === 0) return null;
 
     const heartAnimationStyle = {
       transform: [{ scale: heartScale }],
       opacity: heartOpacity,
     };
 
-    if (isVideo(post.media?.file_path)) {
+    if (mediaItems.length === 1 && mediaItems[0].file_path && isVideo(mediaItems[0].file_path)) {
       return (
         <>
-          <Pressable onPress={handleDoubleTap} style={{ position: "relative" }}>
+          <Pressable onPress={() => handleDoubleTap(0)} style={{ position: "relative" }}>
             <Video
-              source={{ uri: post.media?.file_path }}
+              source={{ uri: mediaItems[0].file_path }}
               style={contentStyle}
               resizeMode={ResizeMode.COVER}
               shouldPlay={false}
               isMuted={true}
               isLooping={false}
               useNativeControls={false}
-              posterSource={{ uri: post.media?.file_path }}
+              posterSource={{ uri: mediaItems[0].file_path }}
               posterStyle={mediaContentStyle}
             />
             <View style={videoOverlayStyle}>
@@ -409,7 +427,7 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
             </Animated.View>
           </Pressable>
           <VideoPlayer
-            videoUri={post.media?.file_path}
+            videoUri={mediaItems[selectedMediaIndex]?.file_path || ""}
             visible={showVideoModal}
             onClose={() => setShowVideoModal(false)}
           />
@@ -417,18 +435,29 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
       );
     }
     return (
-      <Pressable onPress={handleDoubleTap} style={{ position: "relative" }}>
-        <Image
-          source={{ uri: post.media?.file_path }}
-          style={mediaContentStyle}
-          cachePolicy="memory-disk"
-          contentFit="cover"
-          transition={200}
+      <>
+        <View style={{ position: "relative" }}>
+          <MediaGrid
+            items={mediaItems
+              .filter((item) => item.file_path)
+              .map((item) => ({
+                uri: item.file_path || "",
+                isVideo: !!item.file_path && !!isVideo(item.file_path),
+              }))}
+            onPress={handleDoubleTap}
+            height={260}
+            style={mediaContentStyle}
+          />
+          <Animated.View style={[heartOverlayStyle, heartAnimationStyle]} pointerEvents="none">
+            <Icon name="heart" size={64} color="#eb656b" />
+          </Animated.View>
+        </View>
+        <VideoPlayer
+          videoUri={mediaItems[selectedMediaIndex]?.file_path || ""}
+          visible={showVideoModal}
+          onClose={() => setShowVideoModal(false)}
         />
-        <Animated.View style={[heartOverlayStyle, heartAnimationStyle]} pointerEvents="none">
-          <Icon name="heart" size={64} color="#eb656b" />
-        </Animated.View>
-      </Pressable>
+      </>
     );
   };
 
@@ -579,8 +608,8 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
           </View>
         </TouchableOpacity>
       )}
-      {post.body && !post.media?.file_path ? (
-        <Pressable onPress={handleDoubleTap}>
+      {post.body && mediaItems.length === 0 ? (
+        <Pressable onPress={() => handleDoubleTap()}>
           <Text style={textStyle}>{post.body}</Text>
           {translatedText && (
             <View style={translationContainerStyle}>
@@ -601,7 +630,7 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
           {renderMedia()}
         </>
       )}
-      {!post.media?.file_path && (
+      {mediaItems.length === 0 && (
         <Animated.View
           style={[
             heartOverlayStyle,
@@ -662,12 +691,10 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
           ref={storyCardRef}
           username={postUser?.username || "unknown"}
           challengeTitle={post.challenge_title}
-          mediaUrl={post.media?.file_path}
-          postText={post.body}
+          postText={post.body ?? undefined}
           profileImageUrl={profileImageUrl || undefined}
           completionCount={completionCount}
           variant="post"
-          onImageLoad={onImageLoad}
         />
 
         {localPreviews.length > 0 && (
@@ -770,7 +797,8 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
               </TouchableOpacity>
             </View>
             <ImageViewer
-              imageUrls={[{ url: post.media?.file_path || "" }]}
+              imageUrls={imageViewerItems.map((item) => ({ url: item.file_path || "" }))}
+              index={selectedImageViewerIndex}
               enableSwipeDown
               onSwipeDown={() => setShowFullScreenImage(false)}
               renderIndicator={() => <></>}

--- a/src/components/ProfilePage.tsx
+++ b/src/components/ProfilePage.tsx
@@ -288,14 +288,14 @@ export const ProfilePage: React.FC<ProfilePageProps> = ({ userId }) => {
       initializePostLikes(postsInFeed);
       initializePostReactions(postsInFeed);
     }
-  }, [postsInFeed]);
+  }, [initializePostLikes, initializePostReactions, postsInFeed]);
 
   useEffect(() => {
     if (commentsInFeed.length > 0) {
       initializeCommentLikes(commentsInFeed);
       initializeCommentReactions(commentsInFeed);
     }
-  }, [commentsInFeed]);
+  }, [commentsInFeed, initializeCommentLikes, initializeCommentReactions]);
 
   if (progressLoading || profileLoading || !userProfile) {
     return <ProfileSkeleton />;
@@ -559,6 +559,7 @@ export const ProfilePage: React.FC<ProfilePageProps> = ({ userId }) => {
               <CommentPreviewRow
                 username={userProfile.username}
                 text={item.comment.text}
+                hasMedia={!!item.comment.media_items?.length}
                 bodyColor={colors.light.text}
               />
             </TouchableOpacity>

--- a/src/components/Quest.tsx
+++ b/src/components/Quest.tsx
@@ -102,16 +102,18 @@ export const ShareQuestExperience: React.FC<ShareQuestExperienceProps> = ({ ques
           user_id: userId,
           quest_id: quest.id,
         })}
-        onCompleted={({ selectedMedia, submittedText }) => {
+        onCompleted={({ selectedMediaItems, submittedText }) => {
+          const firstSelectedMedia = selectedMediaItems[0] || null;
           submittedTextRef.current = submittedText;
-          setSubmittedMediaPreview(selectedMedia?.previewUrl || null);
+          setSubmittedMediaPreview(firstSelectedMedia?.previewUrl || null);
           queryClient.setQueryData(["quest-completion", quest.id, user?.id], true);
           queryClient.invalidateQueries({ queryKey: ["home-posts"] });
           captureEvent(SIDE_QUEST_EVENTS.DAILY_QUEST_COMPLETED, {
             quest_id: quest.id,
             quest_title: quest.title,
-            has_media: !!selectedMedia,
-            is_video: selectedMedia?.isVideo || false,
+            has_media: selectedMediaItems.length > 0,
+            is_video: firstSelectedMedia?.isVideo || false,
+            media_count: selectedMediaItems.length,
           });
           setUserProperties({
             [USER_PROPERTIES.LAST_ACTIVE]: new Date().toISOString(),

--- a/src/constants/translations.ts
+++ b/src/constants/translations.ts
@@ -76,6 +76,7 @@ export const translations = {
   Posts: "Post",
   All: "Tutti",
   Comments: "Commenti",
+  "Shared media": "Ha condiviso un contenuto",
   "Unknown User": "Utente Sconosciuto",
   "liked your post": "ha messo mi piace al tuo post",
   "liked your comment": "ha messo mi piace al tuo commento",

--- a/src/hooks/useFetchComments.ts
+++ b/src/hooks/useFetchComments.ts
@@ -1,7 +1,8 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { supabase } from "../lib/supabase";
 import { Comment } from "../types";
 import { commentService } from "../services/commentService";
+import { MediaSelectionResult } from "../utils/handleMediaUpload";
+import { backgroundUploadService } from "../services/backgroundUploadService";
 
 export const useFetchComments = (postId: number) => {
   const queryClient = useQueryClient();
@@ -25,40 +26,40 @@ export const useFetchComments = (postId: number) => {
       userId,
       body,
       parentCommentId,
+      mediaItems,
     }: {
       userId: string;
       body: string;
       parentCommentId?: number | null;
+      mediaItems?: MediaSelectionResult[];
     }) => {
-      const { data, error } = await supabase
-        .from("comments")
-        .insert([
-          {
-            post_id: postId,
-            user_id: userId,
-            body,
-            parent_comment_id: parentCommentId ?? null,
-          },
-        ])
-        .select(`
-          *,
-          likes:likes(count)
-        `);
+      const newComment = await commentService.createComment({
+        postId,
+        userId,
+        body,
+        parentCommentId,
+        mediaItems,
+      });
 
-      if (error) throw error;
+      if (mediaItems && mediaItems.length > 0) {
+        let completedUploads = 0;
 
-      const newComment = data?.[0]
-        ? {
-            id: data[0].id,
-            text: data[0].body,
-            userId: data[0].user_id,
-            post_id: postId,
-            parent_comment_id: data[0].parent_comment_id,
-            created_at: data[0].created_at,
-            likes_count: data[0].likes?.count || 0,
-            liked: false,
-          }
-        : null;
+        mediaItems.forEach((item) => {
+          backgroundUploadService.addToQueue(
+            item.mediaId,
+            item.pendingUpload,
+            postId,
+            undefined,
+            () => {
+              completedUploads += 1;
+              if (completedUploads < mediaItems.length) return;
+
+              queryClient.invalidateQueries({ queryKey: ["comments", postId] });
+              queryClient.invalidateQueries({ queryKey: ["home-posts"] });
+            }
+          );
+        });
+      }
 
       return newComment;
     },
@@ -75,8 +76,13 @@ export const useFetchComments = (postId: number) => {
     },
   });
 
-  const addComment = async (userId: string, body: string, parentCommentId?: number | null) => {
-    return addCommentMutation.mutateAsync({ userId, body, parentCommentId });
+  const addComment = async (
+    userId: string,
+    body: string,
+    parentCommentId?: number | null,
+    mediaItems?: MediaSelectionResult[]
+  ) => {
+    return addCommentMutation.mutateAsync({ userId, body, parentCommentId, mediaItems });
   };
 
   return {

--- a/src/hooks/useFetchHomeData.ts
+++ b/src/hooks/useFetchHomeData.ts
@@ -263,15 +263,7 @@ export const useFetchHomeData = (sort: FeedSort = "recent") => {
           *,
           challenges:challenge_id (title),
           side_quests:quest_id (title),
-          media (file_path),
-          post_media (
-            position,
-            media_id,
-            media (
-              file_path,
-              upload_status
-            )
-          ),
+          media:media!post_media_id_fkey (file_path),
           likes:likes(count),
           comments (id, body, created_at, user_id, parent_comment_id, profiles:user_id (username))
         `)
@@ -280,7 +272,22 @@ export const useFetchHomeData = (sort: FeedSort = "recent") => {
 
       if (error) throw error;
 
-      return formatSinglePost(data as PostRecord, likedPosts);
+      let post = data as PostRecord;
+      const { data: postMediaData, error: postMediaError } = await supabase
+        .from("post_media")
+        .select("media_id, position, media (file_path, upload_status)")
+        .eq("post_id", postId);
+
+      if (!postMediaError && postMediaData) {
+        post = {
+          ...post,
+          post_media: postMediaData as unknown as PostRecord["post_media"],
+        };
+      } else if (postMediaError) {
+        console.warn("Post media hydration skipped:", postMediaError);
+      }
+
+      return formatSinglePost(post, likedPosts);
     } catch (error) {
       console.error("Error fetching post:", error);
       return null;

--- a/src/hooks/useFetchHomeData.ts
+++ b/src/hooks/useFetchHomeData.ts
@@ -5,7 +5,12 @@ import { useAuth } from "../contexts/AuthContext";
 import { useLikes } from "../contexts/LikesContext";
 import { useReactions } from "../contexts/ReactionsContext";
 import { useQuery, useInfiniteQuery } from "@tanstack/react-query";
-import { formatFeedPosts, formatSinglePost, postService } from "../services/postService";
+import {
+  formatFeedPosts,
+  formatSinglePost,
+  hydrateSinglePostMedia,
+  postService,
+} from "../services/postService";
 import { captureEvent } from "../lib/posthog";
 import { FEED_EVENTS } from "../constants/analyticsEvents";
 
@@ -272,21 +277,7 @@ export const useFetchHomeData = (sort: FeedSort = "recent") => {
 
       if (error) throw error;
 
-      let post = data as PostRecord;
-      const { data: postMediaData, error: postMediaError } = await supabase
-        .from("post_media")
-        .select("media_id, position, media (file_path, upload_status)")
-        .eq("post_id", postId);
-
-      if (!postMediaError && postMediaData) {
-        post = {
-          ...post,
-          post_media: postMediaData as unknown as PostRecord["post_media"],
-        };
-      } else if (postMediaError) {
-        console.warn("Post media hydration skipped:", postMediaError);
-      }
-
+      const post = await hydrateSinglePostMedia(data as PostRecord);
       return formatSinglePost(post, likedPosts);
     } catch (error) {
       console.error("Error fetching post:", error);

--- a/src/hooks/useFetchHomeData.ts
+++ b/src/hooks/useFetchHomeData.ts
@@ -264,6 +264,14 @@ export const useFetchHomeData = (sort: FeedSort = "recent") => {
           challenges:challenge_id (title),
           side_quests:quest_id (title),
           media (file_path),
+          post_media (
+            position,
+            media_id,
+            media (
+              file_path,
+              upload_status
+            )
+          ),
           likes:likes(count),
           comments (id, body, created_at, user_id, parent_comment_id, profiles:user_id (username))
         `)

--- a/src/hooks/useMediaSelection.ts
+++ b/src/hooks/useMediaSelection.ts
@@ -1,0 +1,78 @@
+import { useState } from "react";
+import { Linking, Platform } from "react-native";
+import { AppAlert } from "../components/AppAlert";
+import { useLanguage } from "../contexts/LanguageContext";
+import { captureEvent } from "../lib/posthog";
+import { POST_EVENTS } from "../constants/analyticsEvents";
+import { MediaSelectionResult, selectMediaItemsForPreview } from "../utils/handleMediaUpload";
+
+const getErrorMessage = (error: unknown) =>
+  error instanceof Error ? error.message : undefined;
+
+export const useMediaSelection = (maxItems = 4) => {
+  const { t } = useLanguage();
+  const [selectedMediaItems, setSelectedMediaItems] = useState<MediaSelectionResult[]>([]);
+  const [isUploading, setIsUploading] = useState(false);
+
+  const handleMediaUpload = async () => {
+    try {
+      setIsUploading(true);
+      const remainingSlots = Math.max(maxItems - selectedMediaItems.length, 0);
+      if (remainingSlots === 0) return;
+
+      const result = await selectMediaItemsForPreview({
+        allowVideo: true,
+        selectionLimit: remainingSlots,
+      });
+
+      if (result.length > 0) {
+        setSelectedMediaItems((prev) => [...prev, ...result].slice(0, maxItems));
+      }
+    } catch (error: unknown) {
+      console.error("Error selecting media:", error);
+      const message = getErrorMessage(error);
+
+      if (message?.includes("permissions not granted")) {
+        captureEvent(POST_EVENTS.MEDIA_PERMISSION_DENIED);
+        AppAlert.show(
+          t("Photo Access Required"),
+          t("Please enable photo library access in Settings to share photos and videos."),
+          [
+            { text: t("Cancel"), style: "cancel" },
+            {
+              text: t("Open Settings"),
+              onPress: () => {
+                if (Platform.OS === "ios") {
+                  Linking.openURL("app-settings:");
+                } else {
+                  Linking.openSettings();
+                }
+              },
+            },
+          ]
+        );
+      } else {
+        captureEvent(POST_EVENTS.MEDIA_PICK_FAILED, { message });
+      }
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const handleRemoveMedia = (index?: number) => {
+    if (index == null) {
+      setSelectedMediaItems([]);
+      return;
+    }
+
+    setSelectedMediaItems((prev) => prev.filter((_, itemIndex) => itemIndex !== index));
+  };
+
+  return {
+    selectedMediaItems,
+    isUploading,
+    handleMediaUpload,
+    handleRemoveMedia,
+    clearMedia: () => setSelectedMediaItems([]),
+  };
+};

--- a/src/hooks/useMediaUpload.ts
+++ b/src/hooks/useMediaUpload.ts
@@ -147,8 +147,6 @@ export const useMediaUpload = (options: UseMediaUploadOptions = {}): UseMediaUpl
 
       if (postError) throw postError;
 
-      let uploadItems = mediaItems;
-
       if (mediaItems.length > 0) {
         const { error: postMediaError } = await supabase
           .from('post_media')
@@ -160,14 +158,11 @@ export const useMediaUpload = (options: UseMediaUploadOptions = {}): UseMediaUpl
             }))
           );
 
-        if (postMediaError) {
-          console.warn("Post media relation insert skipped:", postMediaError);
-          uploadItems = mediaItems.slice(0, 1);
-        }
+        if (postMediaError) throw postMediaError;
       }
 
       // If there's media, start background upload
-      if (uploadItems.length > 0) {
+      if (mediaItems.length > 0) {
         setIsBackgroundUploading(true);
         progressManagerRef.current.startUpload();
 
@@ -175,17 +170,17 @@ export const useMediaUpload = (options: UseMediaUploadOptions = {}): UseMediaUpl
         let completedUploads = 0;
         let failedUploads = 0;
 
-        uploadItems.forEach((item) => {
+        mediaItems.forEach((item) => {
           backgroundUploadService.addToQueue(
             item.mediaId,
             item.pendingUpload,
             postData.id,
             (progress) => {
               uploadProgressByMediaId.set(item.mediaId, progress);
-              const totalProgress = uploadItems.reduce(
+              const totalProgress = mediaItems.reduce(
                 (sum, mediaItem) => sum + (uploadProgressByMediaId.get(mediaItem.mediaId) || 0),
                 0
-              ) / uploadItems.length;
+              ) / mediaItems.length;
               setLocalUploadProgress(totalProgress);
               progressManagerRef.current.updateProgress(totalProgress);
             },
@@ -193,7 +188,7 @@ export const useMediaUpload = (options: UseMediaUploadOptions = {}): UseMediaUpl
               completedUploads += 1;
               if (!success) failedUploads += 1;
 
-              if (completedUploads < uploadItems.length) return;
+              if (completedUploads < mediaItems.length) return;
 
               setIsBackgroundUploading(false);
               setLocalUploadProgress(0);

--- a/src/hooks/useMediaUpload.ts
+++ b/src/hooks/useMediaUpload.ts
@@ -158,7 +158,10 @@ export const useMediaUpload = (options: UseMediaUploadOptions = {}): UseMediaUpl
             }))
           );
 
-        if (postMediaError) throw postMediaError;
+        if (postMediaError) {
+          await supabase.from('post').delete().eq('id', postData.id);
+          throw postMediaError;
+        }
       }
 
       // If there's media, start background upload

--- a/src/hooks/useMediaUpload.ts
+++ b/src/hooks/useMediaUpload.ts
@@ -3,7 +3,7 @@ import { Linking, Platform } from 'react-native';
 import { AppAlert } from '../components/AppAlert';
 import { useUploadProgress } from '../contexts/UploadProgressContext';
 import { createProgressManager } from '../utils/progressManager';
-import { selectMediaForPreview, MediaSelectionResult } from '../utils/handleMediaUpload';
+import { selectMediaItemsForPreview, MediaSelectionResult } from '../utils/handleMediaUpload';
 import { backgroundUploadService } from '../services/backgroundUploadService';
 import { useLanguage } from '../contexts/LanguageContext';
 import { supabase } from '../lib/supabase';
@@ -17,20 +17,24 @@ interface UseMediaUploadOptions {
 
 interface UseMediaUploadResult {
   selectedMedia: MediaSelectionResult | null;
+  selectedMediaItems: MediaSelectionResult[];
   postText: string;
   isUploading: boolean;
   isSubmitting: boolean;
-  isBackgroundUploading: boolean;
-  localUploadProgress: number;
+  uploadProgress: number | null;
   handleMediaUpload: () => Promise<void>;
-  handleRemoveMedia: () => void;
+  handleRemoveMedia: (index?: number) => void;
   setPostText: (text: string) => void;
-  handleSubmit: (additionalData?: Record<string, any>, text?: string) => Promise<void>;
+  handleSubmit: (additionalData?: Record<string, unknown>, text?: string) => Promise<void>;
 }
 
-export const useMediaUpload = (options: UseMediaUploadOptions = {}) => {
+const getErrorMessage = (error: unknown) =>
+  error instanceof Error ? error.message : undefined;
+
+export const useMediaUpload = (options: UseMediaUploadOptions = {}): UseMediaUploadResult => {
   const { t } = useLanguage();
-  const [selectedMedia, setSelectedMedia] = useState<MediaSelectionResult | null>(null);
+  const [selectedMediaItems, setSelectedMediaItems] = useState<MediaSelectionResult[]>([]);
+  const selectedMedia = selectedMediaItems[0] || null;
   const [postText, setPostText] = useState("");
   const [isUploading, setIsUploading] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -41,23 +45,30 @@ export const useMediaUpload = (options: UseMediaUploadOptions = {}) => {
 
   // Cleanup on unmount
   useEffect(() => {
+    const progressManager = progressManagerRef.current;
     return () => {
-      progressManagerRef.current.cleanup();
+      progressManager.cleanup();
     };
   }, []);
 
   const handleMediaUpload = async () => {
     try {
       setIsUploading(true);
-      const result = await selectMediaForPreview({ allowVideo: true });
-      if (result) {
-        setSelectedMedia(result);
+      const remainingSlots = Math.max(4 - selectedMediaItems.length, 0);
+      if (remainingSlots === 0) return;
+      const result = await selectMediaItemsForPreview({
+        allowVideo: true,
+        selectionLimit: remainingSlots,
+      });
+      if (result.length > 0) {
+        setSelectedMediaItems((prev) => [...prev, ...result].slice(0, 4));
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Error selecting media:', error);
+      const message = getErrorMessage(error);
       
       // Check if it's a permissions error
-      if (error?.message?.includes('permissions not granted')) {
+      if (message?.includes('permissions not granted')) {
         captureEvent(POST_EVENTS.MEDIA_PERMISSION_DENIED);
         AppAlert.show(
           t('Photo Access Required'),
@@ -77,7 +88,7 @@ export const useMediaUpload = (options: UseMediaUploadOptions = {}) => {
           ]
         );
       } else {
-        captureEvent(POST_EVENTS.MEDIA_PICK_FAILED, { message: error?.message });
+        captureEvent(POST_EVENTS.MEDIA_PICK_FAILED, { message });
         setUploadMessage(t('Error selecting media'));
       }
     } finally {
@@ -85,14 +96,20 @@ export const useMediaUpload = (options: UseMediaUploadOptions = {}) => {
     }
   };
 
-  const handleRemoveMedia = () => {
-    setSelectedMedia(null);
+  const handleRemoveMedia = (index?: number) => {
+    if (index == null) {
+      setSelectedMediaItems([]);
+      return;
+    }
+    setSelectedMediaItems((prev) => prev.filter((_, itemIndex) => itemIndex !== index));
   };
 
-  const handleSubmit = async (additionalData: Record<string, any> = {}, text?: string) => {
+  const handleSubmit = async (additionalData: Record<string, unknown> = {}, text?: string) => {
     const finalText = text !== undefined ? text : postText;
 
-    if (!finalText.trim() && !selectedMedia) {
+    const mediaItems = selectedMediaItems;
+
+    if (!finalText.trim() && mediaItems.length === 0) {
       setUploadMessage(t('Please add either a description or media'));
       return;
     }
@@ -109,6 +126,7 @@ export const useMediaUpload = (options: UseMediaUploadOptions = {}) => {
     setIsSubmitting(true);
     captureEvent(POST_EVENTS.SUBMIT_ATTEMPTED, {
       has_media: !!selectedMedia,
+      media_count: mediaItems.length,
       has_text: !!finalText.trim(),
     });
 
@@ -118,7 +136,7 @@ export const useMediaUpload = (options: UseMediaUploadOptions = {}) => {
         .from('post')
         .insert([
           {
-            media_id: selectedMedia?.mediaId || null,
+            media_id: mediaItems[0]?.mediaId || null,
             body: finalText,
             featured: false,
             ...additionalData,
@@ -129,45 +147,75 @@ export const useMediaUpload = (options: UseMediaUploadOptions = {}) => {
 
       if (postError) throw postError;
 
+      if (mediaItems.length > 0) {
+        const { error: postMediaError } = await supabase
+          .from('post_media')
+          .insert(
+            mediaItems.map((item, index) => ({
+              post_id: postData.id,
+              media_id: item.mediaId,
+              position: index,
+            }))
+          );
+
+        if (postMediaError) throw postMediaError;
+      }
+
       // If there's media, start background upload
-      if (selectedMedia) {
+      if (mediaItems.length > 0) {
         setIsBackgroundUploading(true);
         progressManagerRef.current.startUpload();
-        
-        backgroundUploadService.addToQueue(
-          selectedMedia.mediaId,
-          selectedMedia.pendingUpload,
-          postData.id,
-          (progress) => {
-            setLocalUploadProgress(progress);
-            progressManagerRef.current.updateProgress(progress);
-          },
-          (success, mediaUrl) => {
-            setIsBackgroundUploading(false);
-            setLocalUploadProgress(0);
-            if (!success) {
-              console.error('Background upload failed:', postData.id);
-              captureEvent(POST_EVENTS.MEDIA_UPLOAD_FAILED, { post_id: postData.id });
-              setUploadMessage(t('Upload failed'));
-              setTimeout(() => {
-                setUploadMessage(null);
-                setUploadProgress(null);
-              }, 3000);
-            } else {
-              progressManagerRef.current.complete();
-              setUploadMessage(options.successMessage || t('Upload completed successfully!'));
-              setTimeout(() => {
-                setUploadMessage(null);
-                setUploadProgress(null);
-              }, 3000);
-              
-              // Call completion callback for successful background upload
-              if (options.onUploadComplete) {
-                options.onUploadComplete();
+
+        const uploadProgressByMediaId = new Map<number, number>();
+        let completedUploads = 0;
+        let failedUploads = 0;
+
+        mediaItems.forEach((item) => {
+          backgroundUploadService.addToQueue(
+            item.mediaId,
+            item.pendingUpload,
+            postData.id,
+            (progress) => {
+              uploadProgressByMediaId.set(item.mediaId, progress);
+              const totalProgress = mediaItems.reduce(
+                (sum, mediaItem) => sum + (uploadProgressByMediaId.get(mediaItem.mediaId) || 0),
+                0
+              ) / mediaItems.length;
+              setLocalUploadProgress(totalProgress);
+              progressManagerRef.current.updateProgress(totalProgress);
+            },
+            (success) => {
+              completedUploads += 1;
+              if (!success) failedUploads += 1;
+
+              if (completedUploads < mediaItems.length) return;
+
+              setIsBackgroundUploading(false);
+              setLocalUploadProgress(0);
+              if (failedUploads > 0) {
+                console.error('Background upload failed:', postData.id);
+                captureEvent(POST_EVENTS.MEDIA_UPLOAD_FAILED, { post_id: postData.id });
+                setUploadMessage(t('Upload failed'));
+                setTimeout(() => {
+                  setUploadMessage(null);
+                  setUploadProgress(null);
+                }, 3000);
+              } else {
+                progressManagerRef.current.complete();
+                setUploadMessage(options.successMessage || t('Upload completed successfully!'));
+                setTimeout(() => {
+                  setUploadMessage(null);
+                  setUploadProgress(null);
+                }, 3000);
+
+                // Call completion callback for successful background upload
+                if (options.onUploadComplete) {
+                  options.onUploadComplete();
+                }
               }
             }
-          }
-        );
+          );
+        });
       } else {
         setUploadMessage(options.successMessage || t('Post sent successfully!'));
         setTimeout(() => setUploadMessage(null), 3000);
@@ -175,7 +223,7 @@ export const useMediaUpload = (options: UseMediaUploadOptions = {}) => {
 
       // Reset form
       setPostText('');
-      setSelectedMedia(null);
+      setSelectedMediaItems([]);
 
       // Call completion callback if provided
       if (options.onUploadComplete) {
@@ -192,6 +240,7 @@ export const useMediaUpload = (options: UseMediaUploadOptions = {}) => {
 
   return {
     selectedMedia,
+    selectedMediaItems,
     postText,
     setPostText,
     isUploading,

--- a/src/hooks/useMediaUpload.ts
+++ b/src/hooks/useMediaUpload.ts
@@ -147,6 +147,8 @@ export const useMediaUpload = (options: UseMediaUploadOptions = {}): UseMediaUpl
 
       if (postError) throw postError;
 
+      let uploadItems = mediaItems;
+
       if (mediaItems.length > 0) {
         const { error: postMediaError } = await supabase
           .from('post_media')
@@ -158,11 +160,14 @@ export const useMediaUpload = (options: UseMediaUploadOptions = {}): UseMediaUpl
             }))
           );
 
-        if (postMediaError) throw postMediaError;
+        if (postMediaError) {
+          console.warn("Post media relation insert skipped:", postMediaError);
+          uploadItems = mediaItems.slice(0, 1);
+        }
       }
 
       // If there's media, start background upload
-      if (mediaItems.length > 0) {
+      if (uploadItems.length > 0) {
         setIsBackgroundUploading(true);
         progressManagerRef.current.startUpload();
 
@@ -170,17 +175,17 @@ export const useMediaUpload = (options: UseMediaUploadOptions = {}): UseMediaUpl
         let completedUploads = 0;
         let failedUploads = 0;
 
-        mediaItems.forEach((item) => {
+        uploadItems.forEach((item) => {
           backgroundUploadService.addToQueue(
             item.mediaId,
             item.pendingUpload,
             postData.id,
             (progress) => {
               uploadProgressByMediaId.set(item.mediaId, progress);
-              const totalProgress = mediaItems.reduce(
+              const totalProgress = uploadItems.reduce(
                 (sum, mediaItem) => sum + (uploadProgressByMediaId.get(mediaItem.mediaId) || 0),
                 0
-              ) / mediaItems.length;
+              ) / uploadItems.length;
               setLocalUploadProgress(totalProgress);
               progressManagerRef.current.updateProgress(totalProgress);
             },
@@ -188,7 +193,7 @@ export const useMediaUpload = (options: UseMediaUploadOptions = {}): UseMediaUpl
               completedUploads += 1;
               if (!success) failedUploads += 1;
 
-              if (completedUploads < mediaItems.length) return;
+              if (completedUploads < uploadItems.length) return;
 
               setIsBackgroundUploading(false);
               setLocalUploadProgress(0);

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -24,7 +24,8 @@ export const useNotifications = () => {
             name
           ),
           comment:comments (
-            body
+            body,
+            media_id
           ),
           challenge:challenges (
             title,
@@ -126,7 +127,8 @@ export const useNotifications = () => {
                   name
                 ),
                 comment:comments (
-                  body
+                  body,
+                  media_id
                 ),
                 challenge:challenges (
                   title,
@@ -183,4 +185,3 @@ export const useNotifications = () => {
     fetchNotifications,
   };
 }; 
-

--- a/src/hooks/useProfileActivity.ts
+++ b/src/hooks/useProfileActivity.ts
@@ -25,8 +25,10 @@ type HydratedRow = {
   item_type: "post" | "comment";
   item_id: number;
   created_at: string;
-  post: any;
-  comment: any;
+  post: (Post & {
+    media?: { file_path?: string | null } | null;
+  }) | null;
+  comment: CommentWithPost | null;
 };
 
 const PAGE_SIZE = 20;
@@ -75,6 +77,41 @@ export const useProfileActivity = (targetUserId: string) => {
           return;
         }
 
+        const postIds = hydrated
+          .filter((r) => r.item_type === "post" && r.post?.id)
+          .map((r) => r.post!.id);
+        const mediaItemsByPost = new Map<number, Post["media_items"]>();
+
+        if (postIds.length > 0) {
+          const { data: postMediaRows, error: postMediaError } = await supabase
+            .from("post_media")
+            .select("post_id, media_id, position, media (file_path, upload_status)")
+            .in("post_id", postIds);
+
+          if (postMediaError) throw postMediaError;
+
+          type PostMediaRow = {
+            post_id: number;
+            media_id: number;
+            position: number;
+            media: { file_path: string | null; upload_status?: string | null } | null;
+          };
+
+          for (const row of (postMediaRows || []) as unknown as PostMediaRow[]) {
+            if (!row.media?.file_path) continue;
+            const items = mediaItemsByPost.get(row.post_id) || [];
+            items.push({
+              media_id: row.media_id,
+              position: row.position,
+              file_path: `${supabaseStorageUrl}/${row.media.file_path}`,
+            });
+            mediaItemsByPost.set(
+              row.post_id,
+              items.sort((a, b) => a.position - b.position)
+            );
+          }
+        }
+
         const nextItems: ActivityItem[] = hydrated
           .map((r) => {
             if (r.item_type === "post") {
@@ -92,6 +129,7 @@ export const useProfileActivity = (targetUserId: string) => {
                 post: {
                   ...post,
                   media,
+                  media_items: mediaItemsByPost.get(post.id),
                   comment_previews:
                     Array.isArray(post.comment_previews) && post.comment_previews.length > 0
                       ? post.comment_previews

--- a/src/hooks/useProfileActivity.ts
+++ b/src/hooks/useProfileActivity.ts
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAuth } from "../contexts/AuthContext";
-import { supabase, supabaseStorageUrl } from "../lib/supabase";
+import { supabase } from "../lib/supabase";
 import { Comment, Post, PostRecord } from "../types";
-import { hydratePostMedia } from "../services/postService";
+import { formatPosts, hydratePostMedia } from "../services/postService";
 
 type CommentWithPost = Comment & {
   post?: Pick<Post, "id" | "body" | "created_at" | "challenge_title" | "quest_id" | "quest_title">;
@@ -86,7 +86,8 @@ export const useProfileActivity = (targetUserId: string) => {
             )
             .map((r) => r.post as PostRecord)
         );
-        const hydratedPostMap = new Map(hydratedPosts.map((post) => [post.id, post]));
+        const formattedPosts = formatPosts(hydratedPosts);
+        const formattedPostMap = new Map(formattedPosts.map((post) => [post.id, post]));
 
         const nextItems: ActivityItem[] = hydrated
           .map((r) => {
@@ -94,36 +95,13 @@ export const useProfileActivity = (targetUserId: string) => {
               const post = r.post;
               if (!post) return null;
 
-              const hydratedPost = hydratedPostMap.get(post.id) || post;
-              const mediaPath = hydratedPost.media?.file_path;
-              const media = {
-                file_path: mediaPath ? `${supabaseStorageUrl}/${mediaPath}` : null,
-              };
+              const formattedPost = formattedPostMap.get(post.id);
+              if (!formattedPost) return null;
 
               return {
                 type: "post" as const,
                 createdAt: r.created_at,
-                post: {
-                  ...hydratedPost,
-                  media,
-                  media_items: hydratedPost.post_media
-                    ?.filter(
-                      (item) =>
-                        item.media?.file_path &&
-                        item.media.upload_status !== "failed" &&
-                        item.media.upload_status !== "pending"
-                    )
-                    .sort((a, b) => a.position - b.position)
-                    .map((item) => ({
-                      media_id: item.media_id,
-                      position: item.position,
-                      file_path: `${supabaseStorageUrl}/${item.media?.file_path}`,
-                    })),
-                  comment_previews:
-                    Array.isArray(hydratedPost.comment_previews) && hydratedPost.comment_previews.length > 0
-                      ? hydratedPost.comment_previews
-                      : undefined,
-                },
+                post: formattedPost,
               };
             }
 

--- a/src/hooks/useProfileActivity.ts
+++ b/src/hooks/useProfileActivity.ts
@@ -88,27 +88,35 @@ export const useProfileActivity = (targetUserId: string) => {
             .select("post_id, media_id, position, media (file_path, upload_status)")
             .in("post_id", postIds);
 
-          if (postMediaError) throw postMediaError;
+          if (postMediaError) {
+            console.warn("Profile post media hydration skipped:", postMediaError);
+          } else {
+            type PostMediaRow = {
+              post_id: number;
+              media_id: number;
+              position: number;
+              media: { file_path: string | null; upload_status?: string | null } | null;
+            };
 
-          type PostMediaRow = {
-            post_id: number;
-            media_id: number;
-            position: number;
-            media: { file_path: string | null; upload_status?: string | null } | null;
-          };
-
-          for (const row of (postMediaRows || []) as unknown as PostMediaRow[]) {
-            if (!row.media?.file_path) continue;
-            const items = mediaItemsByPost.get(row.post_id) || [];
-            items.push({
-              media_id: row.media_id,
-              position: row.position,
-              file_path: `${supabaseStorageUrl}/${row.media.file_path}`,
-            });
-            mediaItemsByPost.set(
-              row.post_id,
-              items.sort((a, b) => a.position - b.position)
-            );
+            for (const row of (postMediaRows || []) as unknown as PostMediaRow[]) {
+              if (
+                !row.media?.file_path ||
+                row.media.upload_status === "failed" ||
+                row.media.upload_status === "pending"
+              ) {
+                continue;
+              }
+              const items = mediaItemsByPost.get(row.post_id) || [];
+              items.push({
+                media_id: row.media_id,
+                position: row.position,
+                file_path: `${supabaseStorageUrl}/${row.media.file_path}`,
+              });
+              mediaItemsByPost.set(
+                row.post_id,
+                items.sort((a, b) => a.position - b.position)
+              );
+            }
           }
         }
 

--- a/src/hooks/useProfileActivity.ts
+++ b/src/hooks/useProfileActivity.ts
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAuth } from "../contexts/AuthContext";
 import { supabase, supabaseStorageUrl } from "../lib/supabase";
-import { Comment, Post } from "../types";
+import { Comment, Post, PostRecord } from "../types";
+import { hydratePostMedia } from "../services/postService";
 
 type CommentWithPost = Comment & {
   post?: Pick<Post, "id" | "body" | "created_at" | "challenge_title" | "quest_id" | "quest_title">;
@@ -39,6 +40,7 @@ export const useProfileActivity = (targetUserId: string) => {
   const [items, setItems] = useState<ActivityItem[]>([]);
   const [loading, setLoading] = useState(false);
   const [hasMore, setHasMore] = useState(true);
+  const fetchNextPageRef = useRef<(reset?: boolean) => Promise<void>>(async () => {});
 
   const lastCursor = useMemo(() => {
     if (items.length === 0) return null;
@@ -77,48 +79,14 @@ export const useProfileActivity = (targetUserId: string) => {
           return;
         }
 
-        const postIds = hydrated
-          .filter((r) => r.item_type === "post" && r.post?.id)
-          .map((r) => r.post!.id);
-        const mediaItemsByPost = new Map<number, Post["media_items"]>();
-
-        if (postIds.length > 0) {
-          const { data: postMediaRows, error: postMediaError } = await supabase
-            .from("post_media")
-            .select("post_id, media_id, position, media (file_path, upload_status)")
-            .in("post_id", postIds);
-
-          if (postMediaError) {
-            console.warn("Profile post media hydration skipped:", postMediaError);
-          } else {
-            type PostMediaRow = {
-              post_id: number;
-              media_id: number;
-              position: number;
-              media: { file_path: string | null; upload_status?: string | null } | null;
-            };
-
-            for (const row of (postMediaRows || []) as unknown as PostMediaRow[]) {
-              if (
-                !row.media?.file_path ||
-                row.media.upload_status === "failed" ||
-                row.media.upload_status === "pending"
-              ) {
-                continue;
-              }
-              const items = mediaItemsByPost.get(row.post_id) || [];
-              items.push({
-                media_id: row.media_id,
-                position: row.position,
-                file_path: `${supabaseStorageUrl}/${row.media.file_path}`,
-              });
-              mediaItemsByPost.set(
-                row.post_id,
-                items.sort((a, b) => a.position - b.position)
-              );
-            }
-          }
-        }
+        const hydratedPosts = await hydratePostMedia(
+          hydrated
+            .filter((r): r is HydratedRow & { item_type: "post"; post: NonNullable<HydratedRow["post"]> } =>
+              r.item_type === "post" && !!r.post
+            )
+            .map((r) => r.post as PostRecord)
+        );
+        const hydratedPostMap = new Map(hydratedPosts.map((post) => [post.id, post]));
 
         const nextItems: ActivityItem[] = hydrated
           .map((r) => {
@@ -126,7 +94,8 @@ export const useProfileActivity = (targetUserId: string) => {
               const post = r.post;
               if (!post) return null;
 
-              const mediaPath = post.media?.file_path;
+              const hydratedPost = hydratedPostMap.get(post.id) || post;
+              const mediaPath = hydratedPost.media?.file_path;
               const media = {
                 file_path: mediaPath ? `${supabaseStorageUrl}/${mediaPath}` : null,
               };
@@ -135,12 +104,24 @@ export const useProfileActivity = (targetUserId: string) => {
                 type: "post" as const,
                 createdAt: r.created_at,
                 post: {
-                  ...post,
+                  ...hydratedPost,
                   media,
-                  media_items: mediaItemsByPost.get(post.id),
+                  media_items: hydratedPost.post_media
+                    ?.filter(
+                      (item) =>
+                        item.media?.file_path &&
+                        item.media.upload_status !== "failed" &&
+                        item.media.upload_status !== "pending"
+                    )
+                    .sort((a, b) => a.position - b.position)
+                    .map((item) => ({
+                      media_id: item.media_id,
+                      position: item.position,
+                      file_path: `${supabaseStorageUrl}/${item.media?.file_path}`,
+                    })),
                   comment_previews:
-                    Array.isArray(post.comment_previews) && post.comment_previews.length > 0
-                      ? post.comment_previews
+                    Array.isArray(hydratedPost.comment_previews) && hydratedPost.comment_previews.length > 0
+                      ? hydratedPost.comment_previews
                       : undefined,
                 },
               };
@@ -169,9 +150,13 @@ export const useProfileActivity = (targetUserId: string) => {
   );
 
   useEffect(() => {
+    fetchNextPageRef.current = fetchNextPage;
+  }, [fetchNextPage]);
+
+  useEffect(() => {
     setItems([]);
     setHasMore(true);
-    fetchNextPage(true);
+    fetchNextPageRef.current(true);
   }, [targetUserId]);
 
   const removePost = useCallback((postId: number) => {

--- a/src/hooks/useUserProgress.ts
+++ b/src/hooks/useUserProgress.ts
@@ -29,7 +29,7 @@ const useUserProgress = (targetUserId: string) => {
           challenge_id,
           is_welcome,
           challenges (title),
-          media (
+          media:media!post_media_id_fkey (
             file_path,
             upload_status
           ),
@@ -158,7 +158,7 @@ const useUserProgress = (targetUserId: string) => {
             id,
             challenge_id,
             created_at,
-            media (
+            media:media!post_media_id_fkey (
               file_path,
               upload_status
             )

--- a/src/hooks/useUserProgress.ts
+++ b/src/hooks/useUserProgress.ts
@@ -1,7 +1,8 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { supabase } from '../lib/supabase';
-import { ChallengeProgress, SideQuestProgress, UserProgress, WeekData, Post } from '../types';
+import { ChallengeProgress, SideQuestProgress, UserProgress, WeekData, Post, PostRecord } from '../types';
 import { useAuth } from '../contexts/AuthContext';
+import { formatFeedPosts, hydratePostMedia } from '../services/postService';
 
 const useUserProgress = (targetUserId: string) => {
   const { user } = useAuth();
@@ -13,7 +14,7 @@ const useUserProgress = (targetUserId: string) => {
   const [hasMorePosts, setHasMorePosts] = useState(true);
   const POSTS_PER_PAGE = 10;
 
-  const fetchUserPosts = async (page = 1, isLoadMore = false) => {
+  const fetchUserPosts = useCallback(async (page = 1, isLoadMore = false) => {
     setPostsLoading(true);
     try {
       // First fetch all posts
@@ -37,21 +38,21 @@ const useUserProgress = (targetUserId: string) => {
           comments (id, body, created_at, parent_comment_id, profiles:user_id (username))
         `)
         .eq('user_id', targetUserId)
-        .neq("media.upload_status", "failed")
-        .neq("media.upload_status", "pending")
         .order('created_at', { ascending: false })
         .range((page - 1) * POSTS_PER_PAGE, page * POSTS_PER_PAGE - 1);
 
       if (error) throw error;
 
+      const hydratedPosts = await hydratePostMedia((posts || []) as PostRecord[]);
+
       // Drop welcome posts from profile feeds
-      const transformedPosts = posts.map(post => ({
+      const transformedPosts = hydratedPosts.map(post => ({
         ...post,
         challenge_title: post.challenges?.title
       })).filter(post => !post.is_welcome);
 
       // Then fetch like status separately
-      const likedPostIds = new Set<string>();
+      const likedPostIds = new Set<number>();
 
       if (transformedPosts.length > 0) {
         const { data: likedPosts } = await supabase
@@ -60,58 +61,23 @@ const useUserProgress = (targetUserId: string) => {
           .eq('user_id', user?.id)
           .in('post_id', transformedPosts.map(post => post.id));
 
-        likedPosts?.forEach(like => likedPostIds.add(like.post_id));
+        likedPosts?.forEach(like => {
+          if (like.post_id != null) likedPostIds.add(like.post_id);
+        });
       }
-
-      // Helper to extract up to 3 comment previews (oldest first)
-      const getCommentPreviews = (post: any) => {
-        if (post.comments && post.comments.length > 0) {
-          // Sort by created_at ascending to get oldest first
-          const sortedComments = [...post.comments].sort(
-            (a: any, b: any) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
-          );
-          // Create a map of comment id to username for reply lookups
-          const commentUserMap = new Map<number, string>();
-          for (const c of post.comments) {
-            if (c?.id && c?.profiles?.username) {
-              commentUserMap.set(c.id, c.profiles.username);
-            }
-          }
-          const previews = sortedComments
-            .slice(0, 3)
-            .filter((c: any) => c?.body && c?.profiles?.username)
-            .map((c: any) => ({
-              username: c.profiles.username,
-              text: c.body,
-              replyToUsername: c.parent_comment_id ? commentUserMap.get(c.parent_comment_id) : undefined,
-            }));
-          return previews.length > 0 ? previews : undefined;
-        }
-        return undefined;
-      };
-
-      const formattedPosts: Post[] = transformedPosts.map(post => ({
-        ...post,
-        media: {
-          file_path: post.media?.file_path
-            ? `${supabase.storageUrl}/object/public/challenge-uploads/${post.media.file_path}`
-            : null,
-        },
-        likes_count: post.likes?.[0]?.count ?? 0,
-        comments_count: post.comments?.length ?? 0,
-        comment_previews: getCommentPreviews(post),
-        challenge_title: post.challenge_title,
-        liked: likedPostIds.has(post.id)
-      }));
+      const likedPostsMap = Object.fromEntries(
+        Array.from(likedPostIds).map((postId) => [postId, true])
+      );
+      const { posts: formattedPosts } = formatFeedPosts(transformedPosts, likedPostsMap);
 
       setUserPosts(prev => isLoadMore ? [...prev, ...formattedPosts] : formattedPosts);
-      setHasMorePosts(posts.length === POSTS_PER_PAGE);
+      setHasMorePosts((posts || []).length === POSTS_PER_PAGE);
     } catch (err) {
       console.error('Error fetching user posts:', err);
     } finally {
       setPostsLoading(false);
     }
-  };
+  }, [targetUserId, user?.id]);
 
   useEffect(() => {
     if (!user?.id) {
@@ -154,7 +120,7 @@ const useUserProgress = (targetUserId: string) => {
         // Fetch submissions for the user
         const { data: submissionData, error: submissionError } = await supabase
           .from('post')
-          .select(`
+        .select(`
             id,
             challenge_id,
             created_at,
@@ -164,9 +130,7 @@ const useUserProgress = (targetUserId: string) => {
             )
           `)
           .eq('user_id', user.id)
-          .not('challenge_id', 'is', null)
-          .neq("media.upload_status", "failed")
-          .neq("media.upload_status", "pending");
+          .not('challenge_id', 'is', null);
 
         if (submissionError) throw submissionError;
 
@@ -250,7 +214,7 @@ const useUserProgress = (targetUserId: string) => {
     if (user?.id) {
       fetchUserPosts(1);
     }
-  }, [user?.id]);
+  }, [fetchUserPosts, user?.id]);
 
   return {
     data,

--- a/src/hooks/useUserProgress.ts
+++ b/src/hooks/useUserProgress.ts
@@ -120,7 +120,7 @@ const useUserProgress = (targetUserId: string) => {
         // Fetch submissions for the user
         const { data: submissionData, error: submissionError } = await supabase
           .from('post')
-        .select(`
+          .select(`
             id,
             challenge_id,
             created_at,
@@ -130,7 +130,9 @@ const useUserProgress = (targetUserId: string) => {
             )
           `)
           .eq('user_id', user.id)
-          .not('challenge_id', 'is', null);
+          .not('challenge_id', 'is', null)
+          .neq('media.upload_status', 'failed')
+          .neq('media.upload_status', 'pending');
 
         if (submissionError) throw submissionError;
 

--- a/src/services/backgroundUploadService.ts
+++ b/src/services/backgroundUploadService.ts
@@ -71,6 +71,8 @@ class BackgroundUploadService {
 
   // Process the upload queue
   private async processQueue() {
+    if (this.isProcessing) return;
+
     this.isProcessing = true;
     console.log('Starting upload queue processing');
 

--- a/src/services/backgroundUploadService.ts
+++ b/src/services/backgroundUploadService.ts
@@ -71,8 +71,6 @@ class BackgroundUploadService {
 
   // Process the upload queue
   private async processQueue() {
-    if (this.isProcessing) return;
-    
     this.isProcessing = true;
     console.log('Starting upload queue processing');
 

--- a/src/services/commentService.ts
+++ b/src/services/commentService.ts
@@ -1,7 +1,115 @@
 import { supabase } from "../lib/supabase";
-import { Comment } from "../types";
+import { imageService } from "./imageService";
+import { Comment, CommentRecord } from "../types";
+import { MediaSelectionResult } from "../utils/handleMediaUpload";
+
+type CommentMediaRow = {
+  comment_id: number;
+  media_id: number;
+  position: number;
+  media: {
+    file_path: string | null;
+    upload_status?: string | null;
+  } | null;
+};
+
+function resolveMediaUrl(filePath?: string | null): string | null {
+  if (!filePath) return null;
+  if (filePath.startsWith("http")) return filePath;
+
+  if (/\.(mp4|mov|avi|wmv)$/i.test(filePath)) {
+    return imageService.getPublicMediaUrlSync(filePath);
+  }
+
+  return imageService.getPostImageUrlSync(filePath);
+}
+
+function normalizeMediaItems(comment: CommentRecord): Comment["media_items"] {
+  const mediaUrl = resolveMediaUrl(comment.media?.file_path);
+  const mediaItems = (comment.comment_media || [])
+    .filter(
+      (item) =>
+        item.media?.file_path &&
+        item.media.upload_status !== "failed" &&
+        item.media.upload_status !== "pending"
+    )
+    .sort((a, b) => a.position - b.position)
+    .map((item) => ({
+      media_id: item.media_id,
+      file_path: resolveMediaUrl(item.media?.file_path) || item.media?.file_path || null,
+      position: item.position,
+      is_video: !!item.media?.file_path && /\.(mp4|mov|avi|wmv)$/i.test(item.media.file_path),
+    }));
+
+  return mediaItems.length > 0
+    ? mediaItems
+    : mediaUrl || comment.media?.file_path
+      ? [
+          {
+            media_id: comment.media_id || 0,
+            file_path: mediaUrl || comment.media?.file_path || null,
+            position: 0,
+            is_video: !!(comment.media?.file_path && /\.(mp4|mov|avi|wmv)$/i.test(comment.media.file_path)),
+          },
+        ]
+      : undefined;
+}
+
+function formatComment(comment: CommentRecord): Comment {
+  const mediaUrl = resolveMediaUrl(comment.media?.file_path);
+  const mediaItems = normalizeMediaItems(comment);
+  const rawText = comment.body || "";
+  const text = rawText === "🖼️" && (mediaItems?.length ?? 0) > 0 ? "" : rawText;
+
+  return {
+    id: comment.id,
+    text,
+    userId: comment.user_id,
+    post_id: comment.post_id,
+    parent_comment_id: comment.parent_comment_id,
+    created_at: comment.created_at,
+    media_id: comment.media_id ?? undefined,
+    media: mediaUrl ? { file_path: mediaUrl } : comment.media ? { file_path: comment.media.file_path } : undefined,
+    media_items: mediaItems,
+    likes_count: comment.likes?.[0]?.count ?? 0,
+    liked: false,
+  };
+}
 
 export const commentService = {
+  async hydrateCommentMedia(comments: CommentRecord[]): Promise<CommentRecord[]> {
+    const commentIds = comments.map((comment) => comment.id);
+    if (commentIds.length === 0) return comments;
+
+    try {
+      const { data, error } = await supabase
+        .from("comment_media")
+        .select("comment_id, media_id, position, media (file_path, upload_status)")
+        .in("comment_id", commentIds);
+
+      if (error) throw error;
+
+      const mediaByCommentId = new Map<number, CommentRecord["comment_media"]>();
+      for (const row of (data || []) as unknown as CommentMediaRow[]) {
+        const items = mediaByCommentId.get(row.comment_id) || [];
+        items.push({
+          media_id: row.media_id,
+          position: row.position,
+          media: row.media,
+        });
+        mediaByCommentId.set(row.comment_id, items);
+      }
+
+      return comments.map((comment) => ({
+        ...comment,
+        comment_media: mediaByCommentId.get(comment.id)?.sort((a, b) => a.position - b.position),
+      }));
+    } catch (error) {
+      console.warn("Comment media hydration skipped:", error);
+      return comments;
+    }
+  },
+
   async fetchComments(postId: number): Promise<Comment[]> {
     if (!postId) {
       throw new Error("Post ID is required");
@@ -15,8 +123,14 @@ export const commentService = {
           id,
           user_id,
           body,
+          post_id,
           created_at,
           parent_comment_id,
+          media_id,
+          media:media!comments_media_id_fkey (
+            file_path,
+            upload_status
+          ),
           likes:likes(count)
         `
         )
@@ -25,23 +139,80 @@ export const commentService = {
 
       if (error) throw error;
 
-      // Transform the data to match the Comment interface
-      const formattedComments =
-        data?.map((comment) => ({
-          id: comment.id,
-          text: comment.body,
-          userId: comment.user_id,
-          post_id: postId,
-          parent_comment_id: comment.parent_comment_id,
-          created_at: comment.created_at,
-          likes_count: comment.likes?.count || 0,
-          liked: false, // This will be updated by initializeCommentLikes
-        })) || [];
-
-      return formattedComments;
+      const hydratedComments = await this.hydrateCommentMedia((data || []) as CommentRecord[]);
+      return hydratedComments.map(formatComment);
     } catch (error) {
       console.error("Error fetching comments:", error);
       throw error; // Re-throw for React Query to handle
     }
+  },
+
+  async createComment(args: {
+    postId: number;
+    userId: string;
+    body: string;
+    parentCommentId?: number | null;
+    mediaItems?: MediaSelectionResult[];
+  }): Promise<Comment> {
+    const { postId, userId, body, parentCommentId, mediaItems = [] } = args;
+    const trimmed = body.trim();
+    const normalizedBody = trimmed || (mediaItems.length > 0 ? "🖼️" : trimmed);
+
+    const { data, error } = await supabase
+      .from("comments")
+      .insert([
+        {
+          post_id: postId,
+          user_id: userId,
+          body: normalizedBody,
+          parent_comment_id: parentCommentId ?? null,
+          media_id: mediaItems[0]?.mediaId || null,
+        },
+      ])
+      .select(`
+        id,
+        user_id,
+        body,
+        post_id,
+        created_at,
+        parent_comment_id,
+        media_id,
+        media:media!comments_media_id_fkey (
+          file_path,
+          upload_status
+        ),
+        likes:likes(count)
+      `)
+      .single();
+
+    if (error) throw error;
+
+    if (mediaItems.length > 0) {
+      const { error: commentMediaError } = await supabase
+        .from("comment_media")
+        .insert(
+          mediaItems.map((item, index) => ({
+            comment_id: data.id,
+            media_id: item.mediaId,
+            position: index,
+          }))
+        );
+
+      if (commentMediaError) throw commentMediaError;
+    }
+
+    const comment = formatComment(data as CommentRecord);
+    if (mediaItems.length === 0) return comment;
+
+    return {
+      ...comment,
+      media_items: mediaItems.map((item, index) => ({
+        media_id: item.mediaId,
+        file_path: item.isVideo ? item.pendingUpload.originalUri : item.previewUrl,
+        preview_path: item.thumbnailUri || item.previewUrl,
+        position: index,
+        is_video: item.isVideo,
+      })),
+    };
   },
 };

--- a/src/services/postService.ts
+++ b/src/services/postService.ts
@@ -14,17 +14,9 @@ const BASE_SELECT = `
       file_path
     )
   ),
-  media (
+  media:media!post_media_id_fkey (
     file_path,
     upload_status
-  ),
-  post_media (
-    position,
-    media_id,
-    media (
-      file_path,
-      upload_status
-    )
   ),
   likes:likes(count),
   comments (
@@ -78,7 +70,12 @@ function getCommentPreviews(post: PostRecord) {
 function normalizePost(post: PostRecord, likedPosts: Record<number, boolean> = {}): Post {
   const mediaUrl = resolveMediaUrl(post.media?.file_path);
   const mediaItems = (post.post_media || [])
-    .filter((item) => item.media?.file_path)
+    .filter(
+      (item) =>
+        item.media?.file_path &&
+        item.media.upload_status !== "failed" &&
+        item.media.upload_status !== "pending"
+    )
     .sort((a, b) => a.position - b.position)
     .map((item) => ({
       media_id: item.media_id,
@@ -157,6 +154,49 @@ function applyBlockedFilter<T extends { not: (column: string, operator: string, 
   return query.not("user_id", "in", quotedList);
 }
 
+async function hydratePostMedia(posts: PostRecord[]): Promise<PostRecord[]> {
+  const postIds = posts.map((post) => post.id);
+  if (postIds.length === 0) return posts;
+
+  try {
+    const { data, error } = await supabase
+      .from("post_media")
+      .select("post_id, media_id, position, media (file_path, upload_status)")
+      .in("post_id", postIds);
+
+    if (error) throw error;
+
+    type PostMediaRow = {
+      post_id: number;
+      media_id: number;
+      position: number;
+      media: {
+        file_path: string | null;
+        upload_status?: string | null;
+      } | null;
+    };
+
+    const mediaByPostId = new Map<number, PostRecord["post_media"]>();
+    for (const row of (data || []) as unknown as PostMediaRow[]) {
+      const items = mediaByPostId.get(row.post_id) || [];
+      items.push({
+        media_id: row.media_id,
+        position: row.position,
+        media: row.media,
+      });
+      mediaByPostId.set(row.post_id, items);
+    }
+
+    return posts.map((post) => ({
+      ...post,
+      post_media: mediaByPostId.get(post.id)?.sort((a, b) => a.position - b.position),
+    }));
+  } catch (error) {
+    console.warn("Post media hydration skipped:", error);
+    return posts;
+  }
+}
+
 export const postService = {
   async fetchPostsForChallenge(
     challengeId: number,
@@ -182,7 +222,7 @@ export const postService = {
     const { data, error } = await query;
     if (error) throw error;
 
-    const rows = (data ?? []) as PostRecord[];
+    const rows = await hydratePostMedia((data ?? []) as PostRecord[]);
     return { posts: rows, hasMore: rows.length === postsPerPage };
   },
 
@@ -658,7 +698,7 @@ export const postService = {
     const { data, error } = await query;
     if (error) throw error;
 
-    const rows = (data ?? []) as PostRecord[];
+    const rows = await hydratePostMedia((data ?? []) as PostRecord[]);
 
     if (feedType === "discussion" && rows.length > 0) {
       const newest = rows[0].created_at;
@@ -682,7 +722,8 @@ export const postService = {
       const { data: welcomeData, error: welcomeError } = await welcomeQuery;
       if (welcomeError) throw welcomeError;
 
-      const merged = [...rows, ...((welcomeData ?? []) as PostRecord[])]
+      const welcomeRows = await hydratePostMedia((welcomeData ?? []) as PostRecord[]);
+      const merged = [...rows, ...welcomeRows]
         .filter((p, i, arr) => arr.findIndex((x) => x.id === p.id) === i)
         .sort((a, b) => (a.created_at > b.created_at ? -1 : a.created_at < b.created_at ? 1 : 0));
 
@@ -722,7 +763,7 @@ export const postService = {
 
     if (error) throw error;
 
-    const rows = (data ?? []) as PostRecord[];
+    const rows = await hydratePostMedia((data ?? []) as PostRecord[]);
     const postMap = new Map(rows.map((p) => [p.id, p]));
     const posts = orderedIds
       .map((id) => postMap.get(id))

--- a/src/services/postService.ts
+++ b/src/services/postService.ts
@@ -67,7 +67,17 @@ function getCommentPreviews(post: PostRecord) {
   return previews.length > 0 ? previews : undefined;
 }
 
-function normalizePost(post: PostRecord, likedPosts: Record<number, boolean> = {}): Post {
+export type PostMediaRow = {
+  post_id: number;
+  media_id: number;
+  position: number;
+  media: {
+    file_path: string | null;
+    upload_status?: string | null;
+  } | null;
+};
+
+function normalizeMediaItems(post: PostRecord): Post["media_items"] {
   const mediaUrl = resolveMediaUrl(post.media?.file_path);
   const mediaItems = (post.post_media || [])
     .filter(
@@ -82,7 +92,8 @@ function normalizePost(post: PostRecord, likedPosts: Record<number, boolean> = {
       file_path: resolveMediaUrl(item.media?.file_path) || item.media?.file_path || null,
       position: item.position,
     }));
-  const normalizedMediaItems = mediaItems.length > 0
+
+  return mediaItems.length > 0
     ? mediaItems
     : mediaUrl || post.media?.file_path
       ? [
@@ -93,6 +104,21 @@ function normalizePost(post: PostRecord, likedPosts: Record<number, boolean> = {
           },
         ]
       : undefined;
+}
+
+function hasRenderableBody(post: PostRecord): boolean {
+  return typeof post.body === "string" && post.body.trim().length > 0;
+}
+
+function isRenderablePost(post: PostRecord): boolean {
+  return post.is_welcome === true ||
+    hasRenderableBody(post) ||
+    (normalizeMediaItems(post)?.length ?? 0) > 0;
+}
+
+function normalizePost(post: PostRecord, likedPosts: Record<number, boolean> = {}): Post {
+  const mediaUrl = resolveMediaUrl(post.media?.file_path);
+  const normalizedMediaItems = normalizeMediaItems(post);
   const { comments, likes, challenges, side_quests } = post;
 
   return {
@@ -154,7 +180,7 @@ function applyBlockedFilter<T extends { not: (column: string, operator: string, 
   return query.not("user_id", "in", quotedList);
 }
 
-async function hydratePostMedia(posts: PostRecord[]): Promise<PostRecord[]> {
+export async function hydratePostMedia(posts: PostRecord[]): Promise<PostRecord[]> {
   const postIds = posts.map((post) => post.id);
   if (postIds.length === 0) return posts;
 
@@ -165,16 +191,6 @@ async function hydratePostMedia(posts: PostRecord[]): Promise<PostRecord[]> {
       .in("post_id", postIds);
 
     if (error) throw error;
-
-    type PostMediaRow = {
-      post_id: number;
-      media_id: number;
-      position: number;
-      media: {
-        file_path: string | null;
-        upload_status?: string | null;
-      } | null;
-    };
 
     const mediaByPostId = new Map<number, PostRecord["post_media"]>();
     for (const row of (data || []) as unknown as PostMediaRow[]) {
@@ -197,6 +213,11 @@ async function hydratePostMedia(posts: PostRecord[]): Promise<PostRecord[]> {
   }
 }
 
+export async function hydrateSinglePostMedia(post: PostRecord): Promise<PostRecord> {
+  const [hydratedPost] = await hydratePostMedia([post]);
+  return hydratedPost || post;
+}
+
 export const postService = {
   async fetchPostsForChallenge(
     challengeId: number,
@@ -210,8 +231,6 @@ export const postService = {
       .from("post")
       .select(select)
       .eq("challenge_id", challengeId)
-      .not("body", "is", null)
-      .not("media.upload_status", "in", '("failed","pending")')
       .order("created_at", { ascending: false });
 
     query = applyBlockedFilter(query, blockedUserIds);
@@ -222,7 +241,7 @@ export const postService = {
     const { data, error } = await query;
     if (error) throw error;
 
-    const rows = await hydratePostMedia((data ?? []) as PostRecord[]);
+    const rows = (await hydratePostMedia((data ?? []) as PostRecord[])).filter(isRenderablePost);
     return { posts: rows, hasMore: rows.length === postsPerPage };
   },
 
@@ -681,7 +700,6 @@ export const postService = {
     let query = supabase
       .from("post")
       .select(select)
-      .not("media.upload_status", "in", '("failed","pending")')
       .order("created_at", { ascending: false });
 
     if (feedType === "challenge") {
@@ -698,7 +716,7 @@ export const postService = {
     const { data, error } = await query;
     if (error) throw error;
 
-    const rows = await hydratePostMedia((data ?? []) as PostRecord[]);
+    const rows = (await hydratePostMedia((data ?? []) as PostRecord[])).filter(isRenderablePost);
 
     if (feedType === "discussion" && rows.length > 0) {
       const newest = rows[0].created_at;
@@ -709,7 +727,6 @@ export const postService = {
         .select(select)
         .is("challenge_id", null)
         .eq("is_welcome", true)
-        .not("media.upload_status", "in", '("failed","pending")')
         .gte("created_at", oldest);
 
       if (pageParam === 1) {
@@ -722,7 +739,9 @@ export const postService = {
       const { data: welcomeData, error: welcomeError } = await welcomeQuery;
       if (welcomeError) throw welcomeError;
 
-      const welcomeRows = await hydratePostMedia((welcomeData ?? []) as PostRecord[]);
+      const welcomeRows = (await hydratePostMedia((welcomeData ?? []) as PostRecord[])).filter(
+        isRenderablePost
+      );
       const merged = [...rows, ...welcomeRows]
         .filter((p, i, arr) => arr.findIndex((x) => x.id === p.id) === i)
         .sort((a, b) => (a.created_at > b.created_at ? -1 : a.created_at < b.created_at ? 1 : 0));
@@ -763,7 +782,7 @@ export const postService = {
 
     if (error) throw error;
 
-    const rows = await hydratePostMedia((data ?? []) as PostRecord[]);
+    const rows = (await hydratePostMedia((data ?? []) as PostRecord[])).filter(isRenderablePost);
     const postMap = new Map(rows.map((p) => [p.id, p]));
     const posts = orderedIds
       .map((id) => postMap.get(id))

--- a/src/services/postService.ts
+++ b/src/services/postService.ts
@@ -18,6 +18,14 @@ const BASE_SELECT = `
     file_path,
     upload_status
   ),
+  post_media (
+    position,
+    media_id,
+    media (
+      file_path,
+      upload_status
+    )
+  ),
   likes:likes(count),
   comments (
     id,
@@ -69,6 +77,25 @@ function getCommentPreviews(post: PostRecord) {
 
 function normalizePost(post: PostRecord, likedPosts: Record<number, boolean> = {}): Post {
   const mediaUrl = resolveMediaUrl(post.media?.file_path);
+  const mediaItems = (post.post_media || [])
+    .filter((item) => item.media?.file_path)
+    .sort((a, b) => a.position - b.position)
+    .map((item) => ({
+      media_id: item.media_id,
+      file_path: resolveMediaUrl(item.media?.file_path) || item.media?.file_path || null,
+      position: item.position,
+    }));
+  const normalizedMediaItems = mediaItems.length > 0
+    ? mediaItems
+    : mediaUrl || post.media?.file_path
+      ? [
+          {
+            media_id: post.media_id || 0,
+            file_path: mediaUrl || post.media?.file_path || null,
+            position: 0,
+          },
+        ]
+      : undefined;
   const { comments, likes, challenges, side_quests } = post;
 
   return {
@@ -77,6 +104,7 @@ function normalizePost(post: PostRecord, likedPosts: Record<number, boolean> = {
     body: post.body,
     media_id: post.media_id ?? undefined,
     media: mediaUrl ? { file_path: mediaUrl } : post.media ? { file_path: post.media.file_path } : undefined,
+    media_items: normalizedMediaItems,
     created_at: post.created_at,
     featured: post.featured,
     challenge_id: post.challenge_id ?? null,

--- a/src/services/postService.ts
+++ b/src/services/postService.ts
@@ -116,7 +116,7 @@ function isRenderablePost(post: PostRecord): boolean {
     (normalizeMediaItems(post)?.length ?? 0) > 0;
 }
 
-function normalizePost(post: PostRecord, likedPosts: Record<number, boolean> = {}): Post {
+export function normalizePost(post: PostRecord, likedPosts: Record<number, boolean> = {}): Post {
   const mediaUrl = resolveMediaUrl(post.media?.file_path);
   const normalizedMediaItems = normalizeMediaItems(post);
   const { comments, likes, challenges, side_quests } = post;
@@ -141,6 +141,13 @@ function normalizePost(post: PostRecord, likedPosts: Record<number, boolean> = {
     quest_title: side_quests?.title,
     comment_previews: getCommentPreviews(post),
   };
+}
+
+export function formatPosts(
+  posts: PostRecord[],
+  likedPosts: Record<number, boolean> = {}
+): Post[] {
+  return posts.map((post) => normalizePost(post, likedPosts));
 }
 
 export function formatFeedPosts(

--- a/src/services/postService.ts
+++ b/src/services/postService.ts
@@ -25,6 +25,7 @@ const BASE_SELECT = `
     created_at,
     user_id,
     parent_comment_id,
+    media_id,
     profiles!comments_user_id_profiles_fkey (
       username
     )
@@ -63,6 +64,7 @@ function getCommentPreviews(post: PostRecord) {
       username: c.profiles.username,
       text: c.body,
       replyToUsername: c.parent_comment_id ? commentUserMap.get(c.parent_comment_id) : undefined,
+      has_media: !!c.media_id,
     }));
   return previews.length > 0 ? previews : undefined;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,14 @@ export interface PostRecord {
     file_path: string | null;
     upload_status?: string | null;
   } | null;
+  post_media?: {
+    position: number;
+    media_id: number;
+    media: {
+      file_path: string | null;
+      upload_status?: string | null;
+    } | null;
+  }[];
   created_at: string;
   featured: boolean;
   challenge_id?: number | null;
@@ -75,6 +83,11 @@ export interface Challenge {
     media?: {
       file_path: string | null;
     };
+    media_items?: {
+      media_id: number;
+      file_path: string | null;
+      position: number;
+    }[];
     created_at: string;
     featured: boolean;
     challenge_id?: number | null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ export interface PostCommentPreview {
   username: string;
   text: string;
   replyToUsername?: string;
+  has_media?: boolean;
 }
 
 export interface PostProfileRecord {
@@ -21,7 +22,33 @@ export interface PostCommentRecord {
   created_at: string;
   user_id: string;
   parent_comment_id: number | null;
+  media_id: number | null;
   profiles: { username: string } | null;
+}
+
+export interface CommentRecord {
+  id: number;
+  user_id: string;
+  body: string | null;
+  created_at: string;
+  post_id: number;
+  parent_comment_id?: number | null;
+  media_id?: number | null;
+  media?: {
+    file_path: string | null;
+    upload_status?: string | null;
+  } | null;
+  comment_media?: {
+    position: number;
+    media_id: number;
+    media: {
+      file_path: string | null;
+      upload_status?: string | null;
+    } | null;
+  }[];
+  likes?: {
+    count: number;
+  }[];
 }
 
 export interface PostRecord {
@@ -153,7 +180,8 @@ export interface Challenge {
     } | null;
     body?: string;
     comment?: {
-      body: string;
+      body: string | null;
+      media_id?: number | null;
     };
   }
 
@@ -164,7 +192,19 @@ export interface Challenge {
     created_at: string;
     post_id: number;
     parent_comment_id?: number | null;
+    media_id?: number;
+    media?: {
+      file_path: string | null;
+    };
+    media_items?: {
+      media_id: number;
+      file_path: string | null;
+      preview_path?: string | null;
+      position: number;
+      is_video?: boolean;
+    }[];
     liked: boolean;
+    likes_count?: number;
     likes?: {
       count: number;
     };

--- a/src/utils/handleMediaUpload.tsx
+++ b/src/utils/handleMediaUpload.tsx
@@ -4,10 +4,16 @@ import * as ImageManipulator from 'expo-image-manipulator';
 import { supabase, supabaseStorageUrl } from "../lib/supabase";
 
 // react-native-compressor requires a dev build, won't work in Expo Go
-let Video: { compress: (uri: string, options: any, onProgress?: (progress: number) => void) => Promise<string> } | null = null;
+let Video: {
+  compress: (
+    uri: string,
+    options: Record<string, unknown>,
+    onProgress?: (progress: number) => void
+  ) => Promise<string>;
+} | null = null;
 try {
   Video = require('react-native-compressor').Video;
-} catch (e) {
+} catch {
   console.warn('react-native-compressor not available (likely running in Expo Go)');
 }
 
@@ -30,6 +36,108 @@ export interface MediaSelectionResult {
   };
 }
 
+const createMediaSelection = async (
+  file: ImagePicker.ImagePickerAsset,
+  timestamp: number,
+  index = 0
+): Promise<MediaSelectionResult> => {
+  const isVideoFile = file.type === "video";
+  let thumbnailUri = null;
+  const mediaType = file.type || "image";
+  const fileExtension = mediaType === "video" ? ".mp4" : ".jpg";
+  const baseFileName = `${mediaType}/${timestamp}_${index}`;
+  const fileName = `${baseFileName}${fileExtension}`;
+  let thumbnailFileName = null;
+  let previewUrl = file.uri;
+
+  if (isVideoFile) {
+    try {
+      thumbnailFileName = `thumbnails/${baseFileName}.jpg`;
+
+      const { uri } = await VideoThumbnails.getThumbnailAsync(file.uri, {
+        time: 0,
+        quality: 0.5,
+      });
+      thumbnailUri = uri;
+
+      if (thumbnailUri) {
+        previewUrl = thumbnailUri;
+      }
+    } catch (e) {
+      console.warn("❌ [VIDEO THUMBNAIL] Couldn't generate or upload thumbnail", e);
+    }
+  }
+
+  const { data: mediaData, error: dbError } = await supabase
+    .from("media")
+    .insert([
+      {
+        file_path: null,
+        thumbnail_path: thumbnailFileName,
+        upload_status: "pending",
+      },
+    ])
+    .select("id")
+    .single();
+
+  if (dbError) throw dbError;
+
+  return {
+    mediaId: mediaData.id,
+    previewUrl,
+    thumbnailUri,
+    isVideo: isVideoFile,
+    pendingUpload: {
+      originalUri: file.uri,
+      fileName,
+      mediaType,
+      thumbnailFileName,
+    },
+  };
+};
+
+export const selectMediaItemsForPreview = async (
+  options: {
+    allowVideo?: boolean;
+    allowsEditing?: boolean;
+    selectionLimit?: number;
+  } = {}
+): Promise<MediaSelectionResult[]> => {
+  const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+
+  if (status !== "granted") {
+    throw new Error("Media library permissions not granted");
+  }
+
+  try {
+    const selectionLimit = Math.min(Math.max(options.selectionLimit ?? 1, 1), 4);
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: options.allowVideo ? ["images", "videos"] : ["images"],
+      allowsEditing: selectionLimit === 1 ? options.allowsEditing ?? false : false,
+      allowsMultipleSelection: selectionLimit > 1,
+      orderedSelection: selectionLimit > 1,
+      quality: 1.0,
+      videoMaxDuration: 120,
+      selectionLimit,
+      exif: false,
+    });
+
+    if (result.canceled) {
+      return [];
+    }
+
+    const timestamp = Date.now();
+    return Promise.all(
+      result.assets.slice(0, selectionLimit).map((file, index) =>
+        createMediaSelection(file, timestamp, index)
+      )
+    );
+  } catch (error) {
+    console.error("❌ [MEDIA SELECT] Error selecting media:", error);
+    throw error;
+  }
+};
+
 /**
  * Selects media from media library to get the preview url and thumbnail uri
  * @param options - The options for the media selection
@@ -41,96 +149,8 @@ export const selectMediaForPreview = async (
     allowsEditing?: boolean;
   } = {}
 ): Promise<MediaSelectionResult | null> => {
-  const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
-
-  if (status !== "granted") {
-    throw new Error("Media library permissions not granted");
-  }
-
-  try {
-    const result = await ImagePicker.launchImageLibraryAsync({
-      mediaTypes: ["images", "videos"],
-      allowsEditing: options.allowsEditing ?? false,
-      quality: 1.0,
-      videoMaxDuration: 120,
-      selectionLimit: 1, // change if we want to allow multiple images
-      exif: false, // no exif -- might make it faster for just selecting media
-    });
-
-    if (result.canceled) {
-      return null;
-    }
-
-    const file = result.assets[0];
-    const isVideoFile = file.type === "video";
-    let thumbnailUri = null;
-
-    const timestamp = Date.now();
-    const mediaType = file.type || "image";
-    const fileExtension = mediaType === "video" ? ".mp4" : ".jpg";
-    const baseFileName = `${mediaType}/${timestamp}`;
-    const fileName = `${baseFileName}${fileExtension}`;
-    let thumbnailFileName = null;
-    let previewUrl = file.uri;
-
-    // Store original URI for background compression
-    const originalUri = file.uri;
-
-    // For videos, generate and upload thumbnail immediately
-    if (isVideoFile) {
-      try {
-        thumbnailFileName = `thumbnails/${baseFileName}.jpg`;
-
-        const { uri } = await VideoThumbnails.getThumbnailAsync(file.uri, {
-          time: 0,
-          quality: 0.5,
-        });
-        thumbnailUri = uri;
-
-        if (thumbnailUri) {
-          // Use local thumbnail immediately, upload later in background
-          previewUrl = thumbnailUri;
-        }
-      } catch (e) {
-        console.warn("❌ [VIDEO THUMBNAIL] Couldn't generate or upload thumbnail", e);
-      }
-    } else {
-      // For images, use original file as preview initially
-      // Final compressed version will be uploaded in background
-      previewUrl = file.uri;
-    }
-
-    // Create media record with upload_status = 'pending'
-    const { data: mediaData, error: dbError } = await supabase
-      .from("media")
-      .insert([
-        {
-          file_path: null, // Will be updated when upload completes
-          thumbnail_path: thumbnailFileName,
-          upload_status: 'pending',
-        },
-      ])
-      .select("id")
-      .single();
-
-    if (dbError) throw dbError;
-
-    return {
-      mediaId: mediaData.id,
-      previewUrl,
-      thumbnailUri,
-      isVideo: isVideoFile,
-      pendingUpload: {
-        originalUri,
-        fileName,
-        mediaType,
-        thumbnailFileName,
-      },
-    };
-  } catch (error) {
-    console.error("❌ [MEDIA SELECT] Error selecting media:", error);
-    throw error;
-  }
+  const items = await selectMediaItemsForPreview({ ...options, selectionLimit: 1 });
+  return items[0] || null;
 };
 
 /**
@@ -172,7 +192,7 @@ export const uploadMediaInBackground = async (
             uri: compressedThumbnail.uri,
             name: pendingUpload.thumbnailFileName,
             type: "image/jpeg",
-          } as any);
+          } as unknown as Blob);
 
           await supabase.storage
             .from("challenge-uploads")
@@ -234,7 +254,7 @@ export const uploadMediaInBackground = async (
       uri: compressedUri,
       name: pendingUpload.fileName,
       type: pendingUpload.mediaType === "video" ? "video/mp4" : "image/jpeg",
-    } as any);
+    } as unknown as Blob);
 
     if (onProgress) onProgress(80);
 
@@ -339,7 +359,7 @@ export const uploadMedia = async (
             uri: compressedThumbnail.uri,
             name: thumbnailFileName,
             type: "image/jpeg",
-          } as any);
+          } as unknown as Blob);
 
           const { error: thumbnailError } = await supabase.storage
             .from("challenge-uploads")
@@ -392,7 +412,7 @@ export const uploadMedia = async (
       uri: fileUri,
       name: fileName,
       type: mediaType === "video" ? "video/mp4" : "image/jpeg",
-    } as any);
+    } as unknown as Blob);
 
     // upload to supabase storage
     const { error: uploadError } = await supabase.storage

--- a/supabase/migrations/20260528000000_add_post_media.sql
+++ b/supabase/migrations/20260528000000_add_post_media.sql
@@ -1,0 +1,73 @@
+CREATE TABLE IF NOT EXISTS public.post_media (
+  post_id integer NOT NULL REFERENCES public.post(id) ON DELETE CASCADE,
+  media_id bigint NOT NULL REFERENCES public.media(id) ON DELETE CASCADE,
+  position smallint NOT NULL,
+  created_at timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT post_media_pkey PRIMARY KEY (post_id, media_id),
+  CONSTRAINT post_media_post_position_key UNIQUE (post_id, position),
+  CONSTRAINT post_media_position_check CHECK (position >= 0 AND position < 4)
+);
+
+CREATE INDEX IF NOT EXISTS post_media_media_id_idx
+  ON public.post_media(media_id);
+
+INSERT INTO public.post_media (post_id, media_id, position)
+SELECT id, media_id, 0
+FROM public.post
+WHERE media_id IS NOT NULL
+ON CONFLICT DO NOTHING;
+
+ALTER TABLE public.post_media ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "post_media_select_authenticated"
+  ON public.post_media FOR SELECT
+  TO authenticated
+  USING (true);
+
+CREATE POLICY "post_media_insert_post_owner"
+  ON public.post_media FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.post
+      WHERE post.id = post_media.post_id
+        AND post.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "post_media_update_post_owner"
+  ON public.post_media FOR UPDATE
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.post
+      WHERE post.id = post_media.post_id
+        AND post.user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.post
+      WHERE post.id = post_media.post_id
+        AND post.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "post_media_delete_post_owner"
+  ON public.post_media FOR DELETE
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.post
+      WHERE post.id = post_media.post_id
+        AND post.user_id = auth.uid()
+    )
+  );
+
+GRANT ALL ON TABLE public.post_media TO anon;
+GRANT ALL ON TABLE public.post_media TO authenticated;
+GRANT ALL ON TABLE public.post_media TO service_role;

--- a/supabase/migrations/20260528120000_add_comment_media.sql
+++ b/supabase/migrations/20260528120000_add_comment_media.sql
@@ -1,0 +1,76 @@
+ALTER TABLE public.comments
+  ADD COLUMN IF NOT EXISTS media_id bigint REFERENCES public.media(id) ON DELETE SET NULL;
+
+CREATE TABLE IF NOT EXISTS public.comment_media (
+  comment_id integer NOT NULL REFERENCES public.comments(id) ON DELETE CASCADE,
+  media_id bigint NOT NULL REFERENCES public.media(id) ON DELETE CASCADE,
+  position smallint NOT NULL,
+  created_at timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT comment_media_pkey PRIMARY KEY (comment_id, media_id),
+  CONSTRAINT comment_media_comment_position_key UNIQUE (comment_id, position),
+  CONSTRAINT comment_media_position_check CHECK (position >= 0 AND position < 4)
+);
+
+CREATE INDEX IF NOT EXISTS comment_media_media_id_idx
+  ON public.comment_media(media_id);
+
+INSERT INTO public.comment_media (comment_id, media_id, position)
+SELECT id, media_id, 0
+FROM public.comments
+WHERE media_id IS NOT NULL
+ON CONFLICT DO NOTHING;
+
+ALTER TABLE public.comment_media ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "comment_media_select_authenticated"
+  ON public.comment_media FOR SELECT
+  TO authenticated
+  USING (true);
+
+CREATE POLICY "comment_media_insert_comment_owner"
+  ON public.comment_media FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.comments
+      WHERE comments.id = comment_media.comment_id
+        AND comments.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "comment_media_update_comment_owner"
+  ON public.comment_media FOR UPDATE
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.comments
+      WHERE comments.id = comment_media.comment_id
+        AND comments.user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.comments
+      WHERE comments.id = comment_media.comment_id
+        AND comments.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "comment_media_delete_comment_owner"
+  ON public.comment_media FOR DELETE
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.comments
+      WHERE comments.id = comment_media.comment_id
+        AND comments.user_id = auth.uid()
+    )
+  );
+
+GRANT ALL ON TABLE public.comment_media TO anon;
+GRANT ALL ON TABLE public.comment_media TO authenticated;
+GRANT ALL ON TABLE public.comment_media TO service_role;


### PR DESCRIPTION
This PR adds support for posts with up to four media items across discussions, challenges, and quests, with a Twitter-style grid for mixed image/video posts and natural sizing for single images.

- Adds ordered multi-media storage through the new `post_media` table while keeping the first media item on the existing post field for compatibility.
- Updates post creation to pick, preview, remove, upload, and save up to four images or videos.
- Renders one, two, three, and four-item media layouts in the feed and detail views, including video playback from grid items.
- Keeps existing single-media posts working and hydrates extra media separately so feed loading stays resilient.