### PR TITLE
add comment images

### DIFF
--- a/src/components/CommentPreviewRow.tsx
+++ b/src/components/CommentPreviewRow.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { View, Text, ViewStyle, TextStyle } from "react-native";
+import MaterialIcons from "@expo/vector-icons/MaterialIcons";
 import { colors } from "../constants/Colors";
 
 type CommentPreviewRowProps = {
@@ -8,6 +9,7 @@ type CommentPreviewRowProps = {
   replyToUsername?: string;
   isLast?: boolean;
   bodyColor?: string;
+  hasMedia?: boolean;
 };
 
 const CommentPreviewRow: React.FC<CommentPreviewRowProps> = ({
@@ -16,6 +18,7 @@ const CommentPreviewRow: React.FC<CommentPreviewRowProps> = ({
   replyToUsername,
   isLast = true,
   bodyColor = colors.neutral.darkGrey,
+  hasMedia = false,
 }) => {
   return (
     <View style={rowStyle}>
@@ -24,10 +27,18 @@ const CommentPreviewRow: React.FC<CommentPreviewRowProps> = ({
       <Text style={[textStyle, { flex: 1 }]} numberOfLines={2}>
         <Text style={usernameStyle}>@{username}:</Text>
         {"  "}
-        {replyToUsername && (
+        {replyToUsername ? (
           <Text style={{ color: bodyColor }}>@{replyToUsername} </Text>
+        ) : null}
+        {hasMedia ? (
+          <>
+            <MaterialIcons name="image" size={13} color={bodyColor} />
+            {" "}
+          </>
+        ) : null}
+        {!text && hasMedia ? null : (
+          <Text style={{ color: bodyColor }}>{text}</Text>
         )}
-        <Text style={{ color: bodyColor }}>{text}</Text>
       </Text>
     </View>
   );

--- a/src/components/Comments.tsx
+++ b/src/components/Comments.tsx
@@ -8,6 +8,7 @@ import {
   Animated,
   PanResponder,
   TouchableOpacity,
+  Modal,
   ViewStyle,
   TextStyle,
   ImageStyle,
@@ -35,6 +36,11 @@ import { ActionsMenu } from "./ActionsMenu";
 import { captureEvent } from "../lib/posthog";
 import { COMMENT_EVENTS } from "../constants/analyticsEvents";
 import { translationService } from "../services/translationService";
+import { MediaSelectionResult } from "../utils/handleMediaUpload";
+import { MediaGrid } from "./MediaGrid";
+import { useMediaSelection } from "../hooks/useMediaSelection";
+import ImageViewer from "react-native-image-zoom-viewer";
+import VideoPlayer from "./VideoPlayer";
 
 interface CommentsProps {
   initialComments: CommentType[];
@@ -43,7 +49,12 @@ interface CommentsProps {
   postId: number;
   postUserId: string;
   onCommentAdded?: (newCount: number) => void;
-  addComment: (userId: string, body: string, parentCommentId?: number | null) => Promise<CommentType | null>;
+  addComment: (
+    userId: string,
+    body: string,
+    parentCommentId?: number | null,
+    mediaItems?: MediaSelectionResult[]
+  ) => Promise<CommentType | null>;
   isAddingComment?: boolean;
 }
 
@@ -55,7 +66,12 @@ interface CommentsListProps {
   postId: number;
   postUserId: string;
   onCommentAdded?: (newCount: number) => void;
-  addComment: (userId: string, body: string, parentCommentId?: number | null) => Promise<CommentType | null>;
+  addComment: (
+    userId: string,
+    body: string,
+    parentCommentId?: number | null,
+    mediaItems?: MediaSelectionResult[]
+  ) => Promise<CommentType | null>;
   isAddingComment?: boolean;
 }
 
@@ -66,6 +82,8 @@ type DisplayComment = CommentType & {
   isLastReply?: boolean;
   replyToUserId?: string;
 };
+
+type CommentMediaItem = NonNullable<CommentType["media_items"]>[number];
 
 const getRootCommentId = (commentsById: Map<number, CommentType>, comment: CommentType) => {
   const visited = new Set<number>();
@@ -143,6 +161,13 @@ export const CommentsList: React.FC<CommentsListProps> = ({
   const [newComment, setNewComment] = useState("");
   const [replyTo, setReplyTo] = useState<{ commentId: number; userId: string; username: string } | null>(null);
   const [comments, setComments] = useState(initialComments);
+  const {
+    selectedMediaItems,
+    isUploading,
+    handleMediaUpload,
+    handleRemoveMedia,
+    clearMedia,
+  } = useMediaSelection();
 
   useEffect(() => {
     setComments(initialComments);
@@ -151,19 +176,25 @@ export const CommentsList: React.FC<CommentsListProps> = ({
       initializeCommentLikes(initialComments);
       initializeCommentReactions(initialComments);
     }
-  }, [initialComments]);
+  }, [initialComments, initializeCommentLikes, initializeCommentReactions]);
 
   const handleAddComment = async () => {
-    if (newComment.trim() && user) {
+    if ((newComment.trim() || selectedMediaItems.length > 0) && user) {
       const commentText = newComment.trim();
 
       try {
         const parentCommentId = replyTo?.commentId ?? null;
-        const newCommentData = await addComment(user.id, commentText, parentCommentId);
+        const newCommentData = await addComment(
+          user.id,
+          commentText,
+          parentCommentId,
+          selectedMediaItems
+        );
 
         if (newCommentData) {
           setNewComment("");
           setReplyTo(null);
+          clearMedia();
 
           setComments((prevComments) => [...prevComments, newCommentData]);
 
@@ -197,7 +228,7 @@ export const CommentsList: React.FC<CommentsListProps> = ({
                   senderUsername,
                   recipientId,
                   postId.toString(),
-                  commentText,
+                  commentText || t("Shared media"),
                   newCommentData.id.toString(),
                   {
                     title: t("(username) commented"),
@@ -215,6 +246,7 @@ export const CommentsList: React.FC<CommentsListProps> = ({
             comment_id: newCommentData.id,
             comment_length: commentText.length,
             is_reply: !!parentCommentId,
+            media_count: selectedMediaItems.length,
           });
         }
       } catch (error) {
@@ -263,6 +295,7 @@ export const CommentsList: React.FC<CommentsListProps> = ({
               text={item.text}
               created_at={item.created_at}
               post_id={item.post_id}
+              mediaItems={item.media_items}
               indentLevel={item.indentLevel}
               isLastReply={item.isLastReply}
               replyToUserId={item.replyToUserId}
@@ -280,6 +313,18 @@ export const CommentsList: React.FC<CommentsListProps> = ({
         />
 
         <View style={inputWrapperStyle}>
+          {selectedMediaItems.length > 0 ? (
+            <MediaGrid
+              items={selectedMediaItems.map((item) => ({
+                uri: item.thumbnailUri || item.previewUrl,
+                isVideo: item.isVideo,
+                useImageForVideo: true,
+              }))}
+              onRemove={handleRemoveMedia}
+              height={132}
+              style={commentMediaPreviewStyle}
+            />
+          ) : null}
           {replyTo ? (
             <View style={replyToContainerStyle}>
               <Text style={replyToTextStyle}>{t("Replying to")} @{replyTo.username}</Text>
@@ -289,6 +334,24 @@ export const CommentsList: React.FC<CommentsListProps> = ({
             </View>
           ) : null}
           <View style={inputContainerStyle}>
+            <TouchableOpacity
+              style={[
+                commentMediaButtonStyle,
+                selectedMediaItems.length >= 4 ? commentMediaButtonDisabledStyle : null,
+              ]}
+              onPress={handleMediaUpload}
+              disabled={selectedMediaItems.length >= 4 || isUploading || isAddingComment}
+            >
+              {isUploading ? (
+                <ActivityIndicator size={18} color={colors.light.primary} />
+              ) : (
+                <MaterialCommunityIcons
+                  name="image-multiple-outline"
+                  size={20}
+                  color={colors.light.primary}
+                />
+              )}
+            </TouchableOpacity>
             <View style={inputInnerContainerStyle}>
               <TextInput
                 value={newComment}
@@ -304,10 +367,10 @@ export const CommentsList: React.FC<CommentsListProps> = ({
               onPress={handleAddComment}
               style={({ pressed }) => [
                 postButtonStyle,
-                (!user || isAddingComment) && postButtonDisabledStyle,
+                (!user || isAddingComment || isUploading) && postButtonDisabledStyle,
                 pressed && postButtonPressedStyle,
               ]}
-              disabled={!user || isAddingComment}
+              disabled={!user || isAddingComment || isUploading}
             >
               <Text style={postButtonTextStyle}>
                 {isAddingComment ? t("Posting...") : t("Post")}
@@ -408,6 +471,7 @@ interface CommentProps {
   text: string;
   created_at: string;
   post_id: number;
+  mediaItems?: CommentType["media_items"];
   indentLevel?: number;
   isLastReply?: boolean;
   replyToUserId?: string;
@@ -421,6 +485,7 @@ const Comment: React.FC<CommentProps> = ({
   text,
   created_at,
   post_id,
+  mediaItems,
   indentLevel = 0,
   isLastReply = false,
   replyToUserId,
@@ -436,6 +501,10 @@ const Comment: React.FC<CommentProps> = ({
   const [replyToUser, setReplyToUser] = useState<User | null>(null);
   const [translatedText, setTranslatedText] = useState<string | null>(null);
   const [isTranslating, setIsTranslating] = useState(false);
+  const [showFullScreenImage, setShowFullScreenImage] = useState(false);
+  const [showVideoModal, setShowVideoModal] = useState(false);
+  const [selectedMediaIndex, setSelectedMediaIndex] = useState(0);
+  const [selectedImageViewerIndex, setSelectedImageViewerIndex] = useState(0);
 
   useEffect(() => {
     const loadUser = async () => {
@@ -485,6 +554,33 @@ const Comment: React.FC<CommentProps> = ({
     } else if (result.error) {
       console.error('Translation error:', result.error);
     }
+  };
+
+  const isVideo = (source?: string | null, mediaItem?: CommentMediaItem) => {
+    if (mediaItem?.is_video != null) return mediaItem.is_video;
+    return !!source?.match(/\.(mp4|mov|avi|wmv)$/i);
+  };
+
+  const imageViewerItems = (mediaItems || []).filter(
+    (item) => item.file_path && !isVideo(item.file_path, item)
+  );
+
+  const handleMediaPress = (mediaIndex: number) => {
+    const item = mediaItems?.[mediaIndex];
+    if (!item?.file_path) return;
+
+    setSelectedMediaIndex(mediaIndex);
+    if (isVideo(item.file_path, item)) {
+      setShowVideoModal(true);
+      return;
+    }
+
+    const imageIndex = (mediaItems || [])
+      .slice(0, mediaIndex)
+      .filter((mediaItem) => mediaItem.file_path && !isVideo(mediaItem.file_path, mediaItem))
+      .length;
+    setSelectedImageViewerIndex(imageIndex);
+    setShowFullScreenImage(true);
   };
 
   return (
@@ -548,12 +644,59 @@ const Comment: React.FC<CommentProps> = ({
           </View>
         </View>
         <View style={commentTextContainerStyle}>
-          <Text style={commentTextStyle}>
-            {indentLevel && replyToUser?.username ? (
-              <Text style={replyToUsernameStyle}>@{replyToUser.username} </Text>
-            ) : null}
-            {text}
-          </Text>
+          {text ? (
+            <Text style={commentTextStyle}>
+              {indentLevel && replyToUser?.username ? (
+                <Text style={replyToUsernameStyle}>@{replyToUser.username} </Text>
+              ) : null}
+              {text}
+            </Text>
+          ) : null}
+          {mediaItems && mediaItems.length > 0 ? (
+            <>
+              <MediaGrid
+                items={mediaItems
+                  .filter((item) => item.file_path)
+                  .map((item) => ({
+                    uri: item.preview_path || item.file_path || "",
+                    isVideo: isVideo(item.file_path, item),
+                    useImageForVideo: isVideo(item.file_path, item) && !!item.preview_path,
+                  }))}
+                onPress={handleMediaPress}
+                height={170}
+                style={commentMediaGridStyle}
+              />
+              <VideoPlayer
+                videoUri={mediaItems[selectedMediaIndex]?.file_path || ""}
+                visible={showVideoModal}
+                onClose={() => setShowVideoModal(false)}
+              />
+              <Modal
+                animationType="fade"
+                transparent
+                visible={showFullScreenImage}
+                onRequestClose={() => setShowFullScreenImage(false)}
+              >
+                <View style={fullScreenContainerStyle}>
+                  <TouchableOpacity
+                    style={closeFullScreenButtonStyle}
+                    onPress={() => setShowFullScreenImage(false)}
+                  >
+                    <MaterialCommunityIcons name="close" size={28} color="white" />
+                  </TouchableOpacity>
+                  <ImageViewer
+                    imageUrls={imageViewerItems.map((item) => ({ url: item.file_path || "" }))}
+                    index={selectedImageViewerIndex}
+                    enableSwipeDown
+                    onSwipeDown={() => setShowFullScreenImage(false)}
+                    renderIndicator={() => <></>}
+                    backgroundColor="rgba(0, 0, 0, 0.95)"
+                    onClick={() => setShowFullScreenImage(false)}
+                  />
+                </View>
+              </Modal>
+            </>
+          ) : null}
           {translatedText && (
             <View style={translationContainerStyle}>
               <Text style={translationLabelStyle}>Translation:</Text>
@@ -641,6 +784,11 @@ const commentTextStyle: TextStyle = {
   fontSize: 14,
 };
 
+const commentMediaGridStyle: ViewStyle = {
+  marginTop: 8,
+  width: "100%",
+};
+
 const replyToUsernameStyle: TextStyle = {
   color: colors.neutral.grey1,
   fontWeight: "600",
@@ -719,7 +867,23 @@ const inputContainerStyle: ViewStyle = {
 
 const inputInnerContainerStyle: ViewStyle = {
   flex: 1,
-  marginRight: 10,
+};
+
+const commentMediaButtonStyle: ViewStyle = {
+  alignItems: "center",
+  justifyContent: "center",
+  marginRight: 8,
+  paddingHorizontal: 4,
+  paddingVertical: 10,
+};
+
+const commentMediaButtonDisabledStyle: ViewStyle = {
+  opacity: 0.45,
+};
+
+const commentMediaPreviewStyle: ViewStyle = {
+  marginBottom: 8,
+  width: "100%",
 };
 
 const replyToContainerStyle: ViewStyle = {
@@ -781,6 +945,19 @@ const postButtonPressedStyle: ViewStyle = {
   opacity: 0.7,
 };
 
+const fullScreenContainerStyle: ViewStyle = {
+  backgroundColor: "rgba(0, 0, 0, 0.95)",
+  flex: 1,
+};
+
+const closeFullScreenButtonStyle: ViewStyle = {
+  padding: 8,
+  position: "absolute",
+  right: 16,
+  top: 50,
+  zIndex: 10,
+};
+
 const commentHeaderStyle: ViewStyle = {
   flexDirection: "row",
   justifyContent: "space-between",
@@ -801,12 +978,6 @@ const iconContainerStyle: ViewStyle = {
   flexDirection: "row",
   alignItems: "center",
   marginRight: 16,
-};
-
-const iconTextStyle: TextStyle = {
-  fontSize: 12,
-  color: colors.neutral.grey1,
-  marginLeft: 4,
 };
 
 const translationContainerStyle: ViewStyle = {

--- a/src/components/Comments.tsx
+++ b/src/components/Comments.tsx
@@ -15,7 +15,7 @@ import {
   ActivityIndicator,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { MaterialCommunityIcons } from "@expo/vector-icons";
+import { MaterialCommunityIcons, MaterialIcons } from "@expo/vector-icons";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { Text } from "./StyledText";
@@ -342,15 +342,11 @@ export const CommentsList: React.FC<CommentsListProps> = ({
               onPress={handleMediaUpload}
               disabled={selectedMediaItems.length >= 4 || isUploading || isAddingComment}
             >
-              {isUploading ? (
-                <ActivityIndicator size={18} color={colors.light.primary} />
-              ) : (
-                <MaterialCommunityIcons
-                  name="image-multiple-outline"
-                  size={20}
-                  color={colors.light.primary}
-                />
-              )}
+              <MaterialIcons
+                name="add-photo-alternate"
+                size={20}
+                color={colors.light.primary}
+              />
             </TouchableOpacity>
             <View style={inputInnerContainerStyle}>
               <TextInput

--- a/src/components/Comments.tsx
+++ b/src/components/Comments.tsx
@@ -228,7 +228,7 @@ export const CommentsList: React.FC<CommentsListProps> = ({
                   senderUsername,
                   recipientId,
                   postId.toString(),
-                  commentText || t("Shared media"),
+                  commentText || "🖼️",
                   newCommentData.id.toString(),
                   {
                     title: t("(username) commented"),

--- a/src/components/DiscussFab.tsx
+++ b/src/components/DiscussFab.tsx
@@ -4,9 +4,7 @@ import {
   TouchableOpacity,
   Modal,
   TextInput,
-  KeyboardAvoidingView,
   Platform,
-  ScrollView,
   Keyboard,
   KeyboardEvent,
   useWindowDimensions,
@@ -37,8 +35,7 @@ const DiscussFab = ({ onPostCreated, bottomOffset = 16 }: DiscussFabProps) => {
   const { height: screenHeight } = useWindowDimensions();
   const [modalVisible, setModalVisible] = useState(false);
   const [keyboardVisible, setKeyboardVisible] = useState(false);
-  const keyboardVerticalOffset = Platform.OS === "ios" ? Math.max(insets.top - 12, 0) : 0;
-  const modalMaxHeight = Math.round(screenHeight * 0.5);
+  const [keyboardHeight, setKeyboardHeight] = useState(0);
 
   React.useEffect(() => {
     const syncKeyboardVisibility = (visible: boolean, event?: KeyboardEvent) => {
@@ -47,6 +44,7 @@ const DiscussFab = ({ onPostCreated, bottomOffset = 16 }: DiscussFabProps) => {
       }
 
       setKeyboardVisible(visible);
+      setKeyboardHeight(visible ? event?.endCoordinates?.height ?? 0 : 0);
     };
 
     const showSubscription = Keyboard.addListener(
@@ -85,6 +83,17 @@ const DiscussFab = ({ onPostCreated, bottomOffset = 16 }: DiscussFabProps) => {
     },
     successMessage: t("Post sent successfully!"),
   });
+  const modalTopPadding = insets.top + 12;
+  const modalBottomPadding = keyboardVisible ? keyboardHeight + 12 : insets.bottom + 12;
+  const availableModalHeight = Math.max(260, screenHeight - modalTopPadding - modalBottomPadding);
+  const modalHeight = Math.round(
+    Math.min(availableModalHeight, screenHeight * (keyboardVisible ? 0.92 : 0.78))
+  );
+  const modalHeaderHeight = 74;
+  const mediaPreviewHeight =
+    selectedMediaItems.length > 0
+      ? Math.max(120, Math.min(190, Math.floor((modalHeight - modalHeaderHeight - 88) / 2)))
+      : 0;
 
   const handleOpen = () => {
     setModalVisible(true);
@@ -125,130 +134,119 @@ const DiscussFab = ({ onPostCreated, bottomOffset = 16 }: DiscussFabProps) => {
         statusBarTranslucent
       >
         <View style={backdropStyle} />
-        <KeyboardAvoidingView
-          behavior={Platform.OS === "ios" ? "padding" : "height"}
-          style={keyboardViewStyle}
-          keyboardVerticalOffset={keyboardVerticalOffset}
+        <View
+          style={[
+            modalContainerStyle,
+            {
+              paddingTop: modalTopPadding,
+              paddingBottom: modalBottomPadding,
+              paddingHorizontal: "5%",
+            },
+          ]}
         >
-          <View
-            style={[
-              modalContainerStyle,
-              {
-                paddingTop: insets.top + 12,
-                paddingBottom: keyboardVisible ? 0 : insets.bottom + 12,
-                paddingHorizontal: "5%",
-              },
-            ]}
-          >
-            <ScrollView
-              style={modalScrollStyle}
-              contentContainerStyle={[
-                scrollContentStyle,
-                { justifyContent: keyboardVisible ? "flex-start" : "center" },
-              ]}
-              showsVerticalScrollIndicator={false}
-              keyboardShouldPersistTaps="handled"
-              keyboardDismissMode="on-drag"
-            >
-              <View style={[modalContentStyle, { maxHeight: modalMaxHeight }]}>
-                <View style={modalHeaderStyle}>
-                  <View style={headerGlowStyle} />
-                  <View style={headerRingStyle} />
-                  <View style={headerFillStyle} />
-                  <Text style={modalTitleStyle}>{t("Start a discussion")}</Text>
-                  <TouchableOpacity
-                    style={closeButtonStyle}
-                    onPress={() => setModalVisible(false)}
-                  >
-                    <MaterialIcons
-                      name="close"
-                      size={20}
-                      color={colors.light.text}
-                      style={closeIconStyle}
-                    />
-                  </TouchableOpacity>
-                </View>
-                <View style={modalBodyStyle}>
-                  {selectedMediaItems.length > 0 ? (
-                    <MediaGrid
-                      items={selectedMediaItems.map((item) => ({
-                        uri: item.thumbnailUri || item.previewUrl,
-                        isVideo: item.isVideo,
-                        useImageForVideo: true,
-                      }))}
-                      onRemove={handleRemoveMedia}
-                      height={210}
-                      style={mediaPreviewContainerStyle}
-                    />
-                  ) : null}
+          <View style={[modalContentStyle, { height: modalHeight }]}>
+            <View style={modalHeaderStyle}>
+              <View style={headerGlowStyle} />
+              <View style={headerRingStyle} />
+              <View style={headerFillStyle} />
+              <Text style={modalTitleStyle}>{t("Start a discussion")}</Text>
+              <TouchableOpacity
+                style={closeButtonStyle}
+                onPress={() => setModalVisible(false)}
+              >
+                <MaterialIcons
+                  name="close"
+                  size={20}
+                  color={colors.light.text}
+                  style={closeIconStyle}
+                />
+              </TouchableOpacity>
+            </View>
+            <View style={modalBodyStyle}>
+              {selectedMediaItems.length > 0 ? (
+                <MediaGrid
+                  items={selectedMediaItems.map((item) => ({
+                    uri: item.thumbnailUri || item.previewUrl,
+                    isVideo: item.isVideo,
+                    useImageForVideo: true,
+                  }))}
+                  onRemove={handleRemoveMedia}
+                  height={mediaPreviewHeight}
+                  style={mediaPreviewContainerStyle}
+                />
+              ) : null}
 
-                  <TextInput
-                    style={textInputStyle}
-                    multiline
-                    scrollEnabled
-                    textAlignVertical="top"
-                    autoFocus
-                    placeholder={t(
-                      "Share your thoughts, start a discussion, or share an achievement..."
-                    )}
-                    placeholderTextColor="#999"
-                    maxLength={1000}
-                    onChangeText={setPostText}
+              <TextInput
+                style={[
+                  textInputStyle,
+                  selectedMediaItems.length > 0
+                    ? textInputWithMediaStyle
+                    : textInputWithoutMediaStyle,
+                ]}
+                multiline
+                scrollEnabled
+                textAlignVertical="top"
+                autoFocus
+                placeholder={t(
+                  "Share your thoughts, start a discussion, or share an achievement..."
+                )}
+                placeholderTextColor="#999"
+                maxLength={1000}
+                onChangeText={setPostText}
+              />
+            </View>
+            <View style={modalFooterStyle}>
+              <View style={mediaUploadContainerStyle}>
+                <TouchableOpacity
+                  style={[
+                    mediaUploadButtonStyle,
+                    selectedMediaItems.length >= 4 ? mediaUploadButtonDisabledStyle : null,
+                  ]}
+                  onPress={handleMediaUpload}
+                  disabled={selectedMediaItems.length >= 4}
+                >
+                  <MaterialIcons
+                    name="add-photo-alternate"
+                    size={20}
+                    color={selectedMediaItems.length >= 4 ? colors.neutral.darkGrey : colors.light.primary}
                   />
+                  <Text
+                    style={[
+                      mediaUploadTextStyle,
+                      selectedMediaItems.length >= 4 ? mediaUploadTextDisabledStyle : null,
+                    ]}
+                  >
+                    {t("Add media")}
+                  </Text>
+                </TouchableOpacity>
 
-                  <View style={mediaUploadContainerStyle}>
-                    <TouchableOpacity
-                      style={[
-                        mediaUploadButtonStyle,
-                        selectedMediaItems.length >= 4 ? mediaUploadButtonDisabledStyle : null,
-                      ]}
-                      onPress={handleMediaUpload}
-                      disabled={selectedMediaItems.length >= 4}
-                    >
-                      <MaterialIcons
-                        name="add-photo-alternate"
-                        size={20}
-                        color={selectedMediaItems.length >= 4 ? colors.neutral.darkGrey : colors.light.primary}
-                      />
-                      <Text
-                        style={[
-                          mediaUploadTextStyle,
-                          selectedMediaItems.length >= 4 ? mediaUploadTextDisabledStyle : null,
-                        ]}
-                      >
-                        {t("Add media")}
-                      </Text>
-                    </TouchableOpacity>
+                <FeatureActionButton
+                  disabled={isSubmitting}
+                  fullWidth={false}
+                  onPress={onSubmit}
+                  showIcon={false}
+                  style={submitButtonStyle}
+                  title={t(isSubmitting ? "Submitting..." : "Submit")}
+                  tone="indigo"
+                  variant="pill"
+                />
+              </View>
 
-                    <FeatureActionButton
-                      disabled={isSubmitting}
-                      fullWidth={false}
-                      onPress={onSubmit}
-                      showIcon={false}
-                      style={submitButtonStyle}
-                      title={t(isSubmitting ? "Submitting..." : "Submit")}
-                      tone="indigo"
-                      variant="pill"
+              {uploadProgress !== null && (
+                <View style={uploadProgressContainerStyle}>
+                  <Text style={uploadProgressTextStyle}>
+                    {t("Uploading media...")} {Math.round(uploadProgress)}%
+                  </Text>
+                  <View style={progressBarContainerStyle}>
+                    <View
+                      style={[progressBarFillStyle, { width: `${uploadProgress}%` }]}
                     />
                   </View>
-
-                  {uploadProgress !== null && (
-                    <View style={uploadProgressContainerStyle}>
-                      <Text style={uploadProgressTextStyle}>
-                        {t("Uploading media...")} {Math.round(uploadProgress)}%
-                      </Text>
-                      <View style={progressBarContainerStyle}>
-                        <View
-                          style={[progressBarFillStyle, { width: `${uploadProgress}%` }]}
-                        />
-                      </View>
-                    </View>
-                  )}
                 </View>
-              </View>
-            </ScrollView>
+              )}
+            </View>
           </View>
-        </KeyboardAvoidingView>
+        </View>
       </Modal>
     </>
   );
@@ -264,10 +262,6 @@ const fabStyle: ViewStyle = {
   elevation: 6,
 };
 
-const keyboardViewStyle: ViewStyle = {
-  flex: 1,
-};
-
 const backdropStyle: ViewStyle = {
   backgroundColor: "rgba(0,0,0,0.5)",
   bottom: 0,
@@ -280,15 +274,7 @@ const backdropStyle: ViewStyle = {
 const modalContainerStyle: ViewStyle = {
   alignItems: "center",
   flex: 1,
-};
-
-const modalScrollStyle: ViewStyle = {
-  flex: 1,
-  width: "100%",
-};
-
-const scrollContentStyle: ViewStyle = {
-  flexGrow: 1,
+  justifyContent: "flex-end",
 };
 
 const modalContentStyle: ViewStyle = {
@@ -296,7 +282,6 @@ const modalContentStyle: ViewStyle = {
   borderColor: colors.light.accent2,
   borderRadius: 26,
   borderWidth: 1,
-  flex: 1,
   overflow: "hidden",
   padding: 0,
   shadowColor: "#000",
@@ -387,7 +372,6 @@ const textInputStyle: TextStyle = {
   borderColor: colors.light.accent2,
   borderRadius: 18,
   borderWidth: 1,
-  flex: 1,
   marginBottom: 6,
   minHeight: 120,
   paddingHorizontal: 14,
@@ -470,6 +454,26 @@ const progressBarFillStyle: ViewStyle = {
 const modalBodyStyle: ViewStyle = {
   flex: 1,
   padding: 20,
+  width: "100%",
+};
+
+const textInputWithMediaStyle: TextStyle = {
+  flex: 1,
+  marginBottom: 0,
+};
+
+const textInputWithoutMediaStyle: TextStyle = {
+  flex: 1,
+  marginBottom: 0,
+};
+
+const modalFooterStyle: ViewStyle = {
+  backgroundColor: "white",
+  borderTopColor: colors.light.accent2,
+  borderTopWidth: 1,
+  paddingHorizontal: 20,
+  paddingTop: 14,
+  paddingBottom: 20,
 };
 
 export default DiscussFab;

--- a/src/components/NotificationSidebar.tsx
+++ b/src/components/NotificationSidebar.tsx
@@ -121,8 +121,9 @@ const NotificationSidebar: React.FC<NotificationSidebarProps> = ({ visible, onCl
     } else if (item.action_type === 'like') {
       notificationText = item.comment_id ? t('liked your comment') : t('liked your post');
     } else if (item.action_type === 'comment') {
-      const commentText = item.comment?.body || '';
-      notificationText = t('commented: "(comment)"', { comment: commentText });
+      const commentText = item.comment?.body?.trim() || '';
+      const previewText = commentText || (item.comment?.media_id ? '🖼️' : '');
+      notificationText = t('commented: "(comment)"', { comment: previewText });
     }
 
     const handlePress = () => {

--- a/src/components/Post.tsx
+++ b/src/components/Post.tsx
@@ -325,7 +325,7 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
             user.user_metadata?.username,
             post.user_id,
             post.id.toString(),
-            commentText || t("Shared media"),
+            commentText || "🖼️",
             newComment.id.toString(),
             {
               title: t("(username) commented"),

--- a/src/components/Post.tsx
+++ b/src/components/Post.tsx
@@ -50,6 +50,7 @@ import { useInstagramShare } from "../hooks/useInstagramShare";
 import { usePostDeleteCleanup } from "../hooks/usePostDeleteCleanup";
 import InstagramStoryCard from "./InstagramStoryCard";
 import { MediaGrid } from "./MediaGrid";
+import { useMediaSelection } from "../hooks/useMediaSelection";
 
 interface PostProps {
   post: PostType;
@@ -103,6 +104,13 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
   const [showVideoModal, setShowVideoModal] = useState(false);
   const [inlineComment, setInlineComment] = useState("");
   const [localPreviews, setLocalPreviews] = useState(post.comment_previews || []);
+  const {
+    selectedMediaItems: inlineCommentMediaItems,
+    isUploading: isInlineCommentMediaUploading,
+    handleMediaUpload: handleInlineCommentMediaUpload,
+    handleRemoveMedia: handleRemoveInlineCommentMedia,
+    clearMedia: clearInlineCommentMedia,
+  } = useMediaSelection();
   const lastTapTime = useRef<number>(0);
   const singleTapTimer = useRef<number | null>(null);
   const heartScale = useRef(new Animated.Value(0)).current;
@@ -289,18 +297,24 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
   };
 
   const handleInlineComment = async () => {
-    if (!inlineComment.trim() || !user) return;
+    if ((!inlineComment.trim() && inlineCommentMediaItems.length === 0) || !user) return;
 
     const commentText = inlineComment.trim();
     setInlineComment("");
 
     try {
-      const newComment = await addCommentMutation(user.id, commentText);
+      const newComment = await addCommentMutation(
+        user.id,
+        commentText,
+        null,
+        inlineCommentMediaItems
+      );
       if (newComment) {
+        clearInlineCommentMedia();
         setCommentCount(prev => prev + 1);
         setLocalPreviews(prev => [...prev, {
           username: currentUserUsername || "unknown",
-          text: commentText,
+          text: commentText || t("Shared media"),
         }]);
 
         if (user.id !== post.user_id) {
@@ -309,7 +323,7 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
             user.user_metadata?.username,
             post.user_id,
             post.id.toString(),
-            commentText,
+            commentText || t("Shared media"),
             newComment.id.toString(),
             {
               title: t("(username) commented"),
@@ -323,6 +337,7 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
           comment_id: newComment.id,
           comment_length: commentText.length,
           source: "inline",
+          media_count: inlineCommentMediaItems.length,
         });
       }
     } catch (error) {
@@ -722,6 +737,33 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
         )}
 
         <View style={inlineCommentContainer}>
+          {inlineCommentMediaItems.length > 0 ? (
+            <MediaGrid
+              items={inlineCommentMediaItems.map((item) => ({
+                uri: item.thumbnailUri || item.previewUrl,
+                isVideo: item.isVideo,
+                useImageForVideo: true,
+              }))}
+              onRemove={handleRemoveInlineCommentMedia}
+              height={120}
+              style={inlineCommentMediaPreviewStyle}
+            />
+          ) : null}
+          <View style={inlineCommentRowStyle}>
+            <TouchableOpacity
+              onPress={handleInlineCommentMediaUpload}
+              disabled={inlineCommentMediaItems.length >= 4 || isInlineCommentMediaUploading || isAddingComment}
+              style={[
+                inlineCommentMediaButtonStyle,
+                (inlineCommentMediaItems.length >= 4 || isInlineCommentMediaUploading) ? inlineCommentMediaButtonDisabledStyle : null,
+              ]}
+            >
+              {isInlineCommentMediaUploading ? (
+                <ActivityIndicator size="small" color={colors.light.primary} />
+              ) : (
+                <Ionicons name="image-outline" size={18} color={colors.light.primary} />
+              )}
+            </TouchableOpacity>
           <TextInput
             style={inlineCommentInput}
             placeholder={t("Add a comment...")}
@@ -734,11 +776,12 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
             textAlignVertical="top"
           />
           <AnimatedSendButton
-            hasContent={inlineComment.trim().length > 0}
+            hasContent={inlineComment.trim().length > 0 || inlineCommentMediaItems.length > 0}
             onPress={handleInlineComment}
-            disabled={isAddingComment}
+            disabled={isAddingComment || isInlineCommentMediaUploading}
             size="small"
           />
+          </View>
         </View>
 
         <Modal
@@ -979,16 +1022,35 @@ const viewAllCommentsStyle: TextStyle = {
 };
 
 const inlineCommentContainer: ViewStyle = {
-  flexDirection: "row",
-  alignItems: "flex-end",
   marginTop: 6,
   paddingHorizontal: 8,
-  gap: 4,
   paddingVertical: 6,
   backgroundColor: colors.neutral.white,
   borderRadius: 8,
   borderWidth: 1,
   borderColor: colors.neutral.grey2,
+};
+
+const inlineCommentRowStyle: ViewStyle = {
+  flexDirection: "row",
+  alignItems: "flex-end",
+  gap: 4,
+};
+
+const inlineCommentMediaPreviewStyle: ViewStyle = {
+  marginBottom: 8,
+  width: "100%",
+};
+
+const inlineCommentMediaButtonStyle: ViewStyle = {
+  alignItems: "center",
+  justifyContent: "center",
+  paddingBottom: 4,
+  paddingHorizontal: 2,
+};
+
+const inlineCommentMediaButtonDisabledStyle: ViewStyle = {
+  opacity: 0.45,
 };
 
 const inlineCommentInput: TextStyle = {

--- a/src/components/Post.tsx
+++ b/src/components/Post.tsx
@@ -18,6 +18,7 @@ import {
 } from "react-native";
 import MaterialCommunityIcons from "react-native-vector-icons/MaterialCommunityIcons";
 import { Ionicons } from "@expo/vector-icons";
+import MaterialIcons from "@expo/vector-icons/MaterialIcons";
 import { MenuProvider } from "react-native-popup-menu";
 import { AnimatedSendButton } from "./AnimatedSendButton";
 import CommentPreviewRow from "./CommentPreviewRow";
@@ -314,7 +315,8 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
         setCommentCount(prev => prev + 1);
         setLocalPreviews(prev => [...prev, {
           username: currentUserUsername || "unknown",
-          text: commentText || t("Shared media"),
+          text: commentText,
+          has_media: inlineCommentMediaItems.length > 0,
         }]);
 
         if (user.id !== post.user_id) {
@@ -722,6 +724,7 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
                   username={preview.username}
                   text={preview.text}
                   replyToUsername={preview.replyToUsername}
+                  hasMedia={preview.has_media}
                   isLast={isLast}
                 />
               );
@@ -758,11 +761,7 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
                 (inlineCommentMediaItems.length >= 4 || isInlineCommentMediaUploading) ? inlineCommentMediaButtonDisabledStyle : null,
               ]}
             >
-              {isInlineCommentMediaUploading ? (
-                <ActivityIndicator size="small" color={colors.light.primary} />
-              ) : (
-                <Ionicons name="image-outline" size={18} color={colors.light.primary} />
-              )}
+              <MaterialIcons name="add-photo-alternate" size={18} color={colors.light.primary} />
             </TouchableOpacity>
           <TextInput
             style={inlineCommentInput}
@@ -1033,7 +1032,7 @@ const inlineCommentContainer: ViewStyle = {
 
 const inlineCommentRowStyle: ViewStyle = {
   flexDirection: "row",
-  alignItems: "flex-end",
+  alignItems: "center",
   gap: 4,
 };
 
@@ -1045,7 +1044,6 @@ const inlineCommentMediaPreviewStyle: ViewStyle = {
 const inlineCommentMediaButtonStyle: ViewStyle = {
   alignItems: "center",
   justifyContent: "center",
-  paddingBottom: 4,
   paddingHorizontal: 2,
 };
 

--- a/src/components/ProfilePage.tsx
+++ b/src/components/ProfilePage.tsx
@@ -558,7 +558,8 @@ export const ProfilePage: React.FC<ProfilePageProps> = ({ userId }) => {
               </Text>
               <CommentPreviewRow
                 username={userProfile.username}
-                text={item.comment.text || t("Shared media")}
+                text={item.comment.text}
+                hasMedia={!!item.comment.media_items?.length}
                 bodyColor={colors.light.text}
               />
             </TouchableOpacity>

--- a/src/components/ProfilePage.tsx
+++ b/src/components/ProfilePage.tsx
@@ -288,14 +288,14 @@ export const ProfilePage: React.FC<ProfilePageProps> = ({ userId }) => {
       initializePostLikes(postsInFeed);
       initializePostReactions(postsInFeed);
     }
-  }, [postsInFeed]);
+  }, [initializePostLikes, initializePostReactions, postsInFeed]);
 
   useEffect(() => {
     if (commentsInFeed.length > 0) {
       initializeCommentLikes(commentsInFeed);
       initializeCommentReactions(commentsInFeed);
     }
-  }, [commentsInFeed]);
+  }, [commentsInFeed, initializeCommentLikes, initializeCommentReactions]);
 
   if (progressLoading || profileLoading || !userProfile) {
     return <ProfileSkeleton />;
@@ -558,7 +558,7 @@ export const ProfilePage: React.FC<ProfilePageProps> = ({ userId }) => {
               </Text>
               <CommentPreviewRow
                 username={userProfile.username}
-                text={item.comment.text}
+                text={item.comment.text || t("Shared media")}
                 bodyColor={colors.light.text}
               />
             </TouchableOpacity>

--- a/src/constants/translations.ts
+++ b/src/constants/translations.ts
@@ -76,6 +76,7 @@ export const translations = {
   Posts: "Post",
   All: "Tutti",
   Comments: "Commenti",
+  "Shared media": "Ha condiviso un contenuto",
   "Unknown User": "Utente Sconosciuto",
   "liked your post": "ha messo mi piace al tuo post",
   "liked your comment": "ha messo mi piace al tuo commento",

--- a/src/hooks/useFetchComments.ts
+++ b/src/hooks/useFetchComments.ts
@@ -1,7 +1,8 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { supabase } from "../lib/supabase";
 import { Comment } from "../types";
 import { commentService } from "../services/commentService";
+import { MediaSelectionResult } from "../utils/handleMediaUpload";
+import { backgroundUploadService } from "../services/backgroundUploadService";
 
 export const useFetchComments = (postId: number) => {
   const queryClient = useQueryClient();
@@ -25,40 +26,40 @@ export const useFetchComments = (postId: number) => {
       userId,
       body,
       parentCommentId,
+      mediaItems,
     }: {
       userId: string;
       body: string;
       parentCommentId?: number | null;
+      mediaItems?: MediaSelectionResult[];
     }) => {
-      const { data, error } = await supabase
-        .from("comments")
-        .insert([
-          {
-            post_id: postId,
-            user_id: userId,
-            body,
-            parent_comment_id: parentCommentId ?? null,
-          },
-        ])
-        .select(`
-          *,
-          likes:likes(count)
-        `);
+      const newComment = await commentService.createComment({
+        postId,
+        userId,
+        body,
+        parentCommentId,
+        mediaItems,
+      });
 
-      if (error) throw error;
+      if (mediaItems && mediaItems.length > 0) {
+        let completedUploads = 0;
 
-      const newComment = data?.[0]
-        ? {
-            id: data[0].id,
-            text: data[0].body,
-            userId: data[0].user_id,
-            post_id: postId,
-            parent_comment_id: data[0].parent_comment_id,
-            created_at: data[0].created_at,
-            likes_count: data[0].likes?.count || 0,
-            liked: false,
-          }
-        : null;
+        mediaItems.forEach((item) => {
+          backgroundUploadService.addToQueue(
+            item.mediaId,
+            item.pendingUpload,
+            postId,
+            undefined,
+            () => {
+              completedUploads += 1;
+              if (completedUploads < mediaItems.length) return;
+
+              queryClient.invalidateQueries({ queryKey: ["comments", postId] });
+              queryClient.invalidateQueries({ queryKey: ["home-posts"] });
+            }
+          );
+        });
+      }
 
       return newComment;
     },
@@ -75,8 +76,13 @@ export const useFetchComments = (postId: number) => {
     },
   });
 
-  const addComment = async (userId: string, body: string, parentCommentId?: number | null) => {
-    return addCommentMutation.mutateAsync({ userId, body, parentCommentId });
+  const addComment = async (
+    userId: string,
+    body: string,
+    parentCommentId?: number | null,
+    mediaItems?: MediaSelectionResult[]
+  ) => {
+    return addCommentMutation.mutateAsync({ userId, body, parentCommentId, mediaItems });
   };
 
   return {

--- a/src/hooks/useMediaSelection.ts
+++ b/src/hooks/useMediaSelection.ts
@@ -1,0 +1,78 @@
+import { useState } from "react";
+import { Linking, Platform } from "react-native";
+import { AppAlert } from "../components/AppAlert";
+import { useLanguage } from "../contexts/LanguageContext";
+import { captureEvent } from "../lib/posthog";
+import { POST_EVENTS } from "../constants/analyticsEvents";
+import { MediaSelectionResult, selectMediaItemsForPreview } from "../utils/handleMediaUpload";
+
+const getErrorMessage = (error: unknown) =>
+  error instanceof Error ? error.message : undefined;
+
+export const useMediaSelection = (maxItems = 4) => {
+  const { t } = useLanguage();
+  const [selectedMediaItems, setSelectedMediaItems] = useState<MediaSelectionResult[]>([]);
+  const [isUploading, setIsUploading] = useState(false);
+
+  const handleMediaUpload = async () => {
+    try {
+      setIsUploading(true);
+      const remainingSlots = Math.max(maxItems - selectedMediaItems.length, 0);
+      if (remainingSlots === 0) return;
+
+      const result = await selectMediaItemsForPreview({
+        allowVideo: true,
+        selectionLimit: remainingSlots,
+      });
+
+      if (result.length > 0) {
+        setSelectedMediaItems((prev) => [...prev, ...result].slice(0, maxItems));
+      }
+    } catch (error: unknown) {
+      console.error("Error selecting media:", error);
+      const message = getErrorMessage(error);
+
+      if (message?.includes("permissions not granted")) {
+        captureEvent(POST_EVENTS.MEDIA_PERMISSION_DENIED);
+        AppAlert.show(
+          t("Photo Access Required"),
+          t("Please enable photo library access in Settings to share photos and videos."),
+          [
+            { text: t("Cancel"), style: "cancel" },
+            {
+              text: t("Open Settings"),
+              onPress: () => {
+                if (Platform.OS === "ios") {
+                  Linking.openURL("app-settings:");
+                } else {
+                  Linking.openSettings();
+                }
+              },
+            },
+          ]
+        );
+      } else {
+        captureEvent(POST_EVENTS.MEDIA_PICK_FAILED, { message });
+      }
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const handleRemoveMedia = (index?: number) => {
+    if (index == null) {
+      setSelectedMediaItems([]);
+      return;
+    }
+
+    setSelectedMediaItems((prev) => prev.filter((_, itemIndex) => itemIndex !== index));
+  };
+
+  return {
+    selectedMediaItems,
+    isUploading,
+    handleMediaUpload,
+    handleRemoveMedia,
+    clearMedia: () => setSelectedMediaItems([]),
+  };
+};

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -24,7 +24,8 @@ export const useNotifications = () => {
             name
           ),
           comment:comments (
-            body
+            body,
+            media_id
           ),
           challenge:challenges (
             title,
@@ -126,7 +127,8 @@ export const useNotifications = () => {
                   name
                 ),
                 comment:comments (
-                  body
+                  body,
+                  media_id
                 ),
                 challenge:challenges (
                   title,
@@ -183,4 +185,3 @@ export const useNotifications = () => {
     fetchNotifications,
   };
 }; 
-

--- a/src/services/commentService.ts
+++ b/src/services/commentService.ts
@@ -1,7 +1,107 @@
 import { supabase } from "../lib/supabase";
-import { Comment } from "../types";
+import { imageService } from "./imageService";
+import { Comment, CommentRecord } from "../types";
+import { MediaSelectionResult } from "../utils/handleMediaUpload";
+
+type CommentMediaRow = {
+  comment_id: number;
+  media_id: number;
+  position: number;
+  media: {
+    file_path: string | null;
+    upload_status?: string | null;
+  } | null;
+};
+
+function resolveMediaUrl(filePath?: string | null): string | null {
+  if (!filePath) return null;
+  if (filePath.startsWith("http")) return filePath;
+
+  if (/\.(mp4|mov|avi|wmv)$/i.test(filePath)) {
+    return imageService.getPublicMediaUrlSync(filePath);
+  }
+
+  return imageService.getPostImageUrlSync(filePath);
+}
+
+function normalizeMediaItems(comment: CommentRecord): Comment["media_items"] {
+  const mediaUrl = resolveMediaUrl(comment.media?.file_path);
+  const mediaItems = (comment.comment_media || [])
+    .filter(
+      (item) =>
+        item.media?.file_path &&
+        item.media.upload_status !== "failed" &&
+        item.media.upload_status !== "pending"
+    )
+    .sort((a, b) => a.position - b.position)
+    .map((item) => ({
+      media_id: item.media_id,
+      file_path: resolveMediaUrl(item.media?.file_path) || item.media?.file_path || null,
+      position: item.position,
+      is_video: !!item.media?.file_path && /\.(mp4|mov|avi|wmv)$/i.test(item.media.file_path),
+    }));
+
+  return mediaItems.length > 0
+    ? mediaItems
+    : mediaUrl || comment.media?.file_path
+      ? [
+          {
+            media_id: comment.media_id || 0,
+            file_path: mediaUrl || comment.media?.file_path || null,
+            position: 0,
+            is_video: !!(comment.media?.file_path && /\.(mp4|mov|avi|wmv)$/i.test(comment.media.file_path)),
+          },
+        ]
+      : undefined;
+}
+
+function formatComment(comment: CommentRecord): Comment {
+  const mediaUrl = resolveMediaUrl(comment.media?.file_path);
+
+  return {
+    id: comment.id,
+    text: comment.body || "",
+    userId: comment.user_id,
+    post_id: comment.post_id,
+    parent_comment_id: comment.parent_comment_id,
+    created_at: comment.created_at,
+    media_id: comment.media_id ?? undefined,
+    media: mediaUrl ? { file_path: mediaUrl } : comment.media ? { file_path: comment.media.file_path } : undefined,
+    media_items: normalizeMediaItems(comment),
+    likes_count: comment.likes?.[0]?.count ?? 0,
+    liked: false,
+  };
+}
 
 export const commentService = {
+  async hydrateCommentMedia(comments: CommentRecord[]): Promise<CommentRecord[]> {
+    const commentIds = comments.map((comment) => comment.id);
+    if (commentIds.length === 0) return comments;
+
+    const { data, error } = await supabase
+      .from("comment_media")
+      .select("comment_id, media_id, position, media (file_path, upload_status)")
+      .in("comment_id", commentIds);
+
+    if (error) throw error;
+
+    const mediaByCommentId = new Map<number, CommentRecord["comment_media"]>();
+    for (const row of (data || []) as unknown as CommentMediaRow[]) {
+      const items = mediaByCommentId.get(row.comment_id) || [];
+      items.push({
+        media_id: row.media_id,
+        position: row.position,
+        media: row.media,
+      });
+      mediaByCommentId.set(row.comment_id, items);
+    }
+
+    return comments.map((comment) => ({
+      ...comment,
+      comment_media: mediaByCommentId.get(comment.id)?.sort((a, b) => a.position - b.position),
+    }));
+  },
+
   async fetchComments(postId: number): Promise<Comment[]> {
     if (!postId) {
       throw new Error("Post ID is required");
@@ -15,8 +115,14 @@ export const commentService = {
           id,
           user_id,
           body,
+          post_id,
           created_at,
           parent_comment_id,
+          media_id,
+          media:media!comments_media_id_fkey (
+            file_path,
+            upload_status
+          ),
           likes:likes(count)
         `
         )
@@ -25,23 +131,79 @@ export const commentService = {
 
       if (error) throw error;
 
-      // Transform the data to match the Comment interface
-      const formattedComments =
-        data?.map((comment) => ({
-          id: comment.id,
-          text: comment.body,
-          userId: comment.user_id,
-          post_id: postId,
-          parent_comment_id: comment.parent_comment_id,
-          created_at: comment.created_at,
-          likes_count: comment.likes?.count || 0,
-          liked: false, // This will be updated by initializeCommentLikes
-        })) || [];
-
-      return formattedComments;
+      const hydratedComments = await this.hydrateCommentMedia((data || []) as CommentRecord[]);
+      return hydratedComments.map(formatComment);
     } catch (error) {
       console.error("Error fetching comments:", error);
       throw error; // Re-throw for React Query to handle
     }
+  },
+
+  async createComment(args: {
+    postId: number;
+    userId: string;
+    body: string;
+    parentCommentId?: number | null;
+    mediaItems?: MediaSelectionResult[];
+  }): Promise<Comment> {
+    const { postId, userId, body, parentCommentId, mediaItems = [] } = args;
+    const normalizedBody = body.trim();
+
+    const { data, error } = await supabase
+      .from("comments")
+      .insert([
+        {
+          post_id: postId,
+          user_id: userId,
+          body: normalizedBody,
+          parent_comment_id: parentCommentId ?? null,
+          media_id: mediaItems[0]?.mediaId || null,
+        },
+      ])
+      .select(`
+        id,
+        user_id,
+        body,
+        post_id,
+        created_at,
+        parent_comment_id,
+        media_id,
+        media:media!comments_media_id_fkey (
+          file_path,
+          upload_status
+        ),
+        likes:likes(count)
+      `)
+      .single();
+
+    if (error) throw error;
+
+    if (mediaItems.length > 0) {
+      const { error: commentMediaError } = await supabase
+        .from("comment_media")
+        .insert(
+          mediaItems.map((item, index) => ({
+            comment_id: data.id,
+            media_id: item.mediaId,
+            position: index,
+          }))
+        );
+
+      if (commentMediaError) throw commentMediaError;
+    }
+
+    const comment = formatComment(data as CommentRecord);
+    if (mediaItems.length === 0) return comment;
+
+    return {
+      ...comment,
+      media_items: mediaItems.map((item, index) => ({
+        media_id: item.mediaId,
+        file_path: item.isVideo ? item.pendingUpload.originalUri : item.previewUrl,
+        preview_path: item.thumbnailUri || item.previewUrl,
+        position: index,
+        is_video: item.isVideo,
+      })),
+    };
   },
 };

--- a/src/services/commentService.ts
+++ b/src/services/commentService.ts
@@ -57,17 +57,20 @@ function normalizeMediaItems(comment: CommentRecord): Comment["media_items"] {
 
 function formatComment(comment: CommentRecord): Comment {
   const mediaUrl = resolveMediaUrl(comment.media?.file_path);
+  const mediaItems = normalizeMediaItems(comment);
+  const rawText = comment.body || "";
+  const text = rawText === "🖼️" && (mediaItems?.length ?? 0) > 0 ? "" : rawText;
 
   return {
     id: comment.id,
-    text: comment.body || "",
+    text,
     userId: comment.user_id,
     post_id: comment.post_id,
     parent_comment_id: comment.parent_comment_id,
     created_at: comment.created_at,
     media_id: comment.media_id ?? undefined,
     media: mediaUrl ? { file_path: mediaUrl } : comment.media ? { file_path: comment.media.file_path } : undefined,
-    media_items: normalizeMediaItems(comment),
+    media_items: mediaItems,
     likes_count: comment.likes?.[0]?.count ?? 0,
     liked: false,
   };
@@ -78,28 +81,33 @@ export const commentService = {
     const commentIds = comments.map((comment) => comment.id);
     if (commentIds.length === 0) return comments;
 
-    const { data, error } = await supabase
-      .from("comment_media")
-      .select("comment_id, media_id, position, media (file_path, upload_status)")
-      .in("comment_id", commentIds);
+    try {
+      const { data, error } = await supabase
+        .from("comment_media")
+        .select("comment_id, media_id, position, media (file_path, upload_status)")
+        .in("comment_id", commentIds);
 
-    if (error) throw error;
+      if (error) throw error;
 
-    const mediaByCommentId = new Map<number, CommentRecord["comment_media"]>();
-    for (const row of (data || []) as unknown as CommentMediaRow[]) {
-      const items = mediaByCommentId.get(row.comment_id) || [];
-      items.push({
-        media_id: row.media_id,
-        position: row.position,
-        media: row.media,
-      });
-      mediaByCommentId.set(row.comment_id, items);
+      const mediaByCommentId = new Map<number, CommentRecord["comment_media"]>();
+      for (const row of (data || []) as unknown as CommentMediaRow[]) {
+        const items = mediaByCommentId.get(row.comment_id) || [];
+        items.push({
+          media_id: row.media_id,
+          position: row.position,
+          media: row.media,
+        });
+        mediaByCommentId.set(row.comment_id, items);
+      }
+
+      return comments.map((comment) => ({
+        ...comment,
+        comment_media: mediaByCommentId.get(comment.id)?.sort((a, b) => a.position - b.position),
+      }));
+    } catch (error) {
+      console.warn("Comment media hydration skipped:", error);
+      return comments;
     }
-
-    return comments.map((comment) => ({
-      ...comment,
-      comment_media: mediaByCommentId.get(comment.id)?.sort((a, b) => a.position - b.position),
-    }));
   },
 
   async fetchComments(postId: number): Promise<Comment[]> {
@@ -147,7 +155,8 @@ export const commentService = {
     mediaItems?: MediaSelectionResult[];
   }): Promise<Comment> {
     const { postId, userId, body, parentCommentId, mediaItems = [] } = args;
-    const normalizedBody = body.trim();
+    const trimmed = body.trim();
+    const normalizedBody = trimmed || (mediaItems.length > 0 ? "🖼️" : trimmed);
 
     const { data, error } = await supabase
       .from("comments")

--- a/src/services/postService.ts
+++ b/src/services/postService.ts
@@ -25,6 +25,7 @@ const BASE_SELECT = `
     created_at,
     user_id,
     parent_comment_id,
+    media_id,
     profiles!comments_user_id_profiles_fkey (
       username
     )
@@ -63,6 +64,7 @@ function getCommentPreviews(post: PostRecord) {
       username: c.profiles.username,
       text: c.body,
       replyToUsername: c.parent_comment_id ? commentUserMap.get(c.parent_comment_id) : undefined,
+      has_media: !!c.media_id,
     }));
   return previews.length > 0 ? previews : undefined;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ export interface PostCommentPreview {
   username: string;
   text: string;
   replyToUsername?: string;
+  has_media?: boolean;
 }
 
 export interface PostProfileRecord {

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ export interface PostCommentRecord {
   created_at: string;
   user_id: string;
   parent_comment_id: number | null;
+  media_id: number | null;
   profiles: { username: string } | null;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -179,7 +179,8 @@ export interface Challenge {
     } | null;
     body?: string;
     comment?: {
-      body: string;
+      body: string | null;
+      media_id?: number | null;
     };
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,31 @@ export interface PostCommentRecord {
   profiles: { username: string } | null;
 }
 
+export interface CommentRecord {
+  id: number;
+  user_id: string;
+  body: string | null;
+  created_at: string;
+  post_id: number;
+  parent_comment_id?: number | null;
+  media_id?: number | null;
+  media?: {
+    file_path: string | null;
+    upload_status?: string | null;
+  } | null;
+  comment_media?: {
+    position: number;
+    media_id: number;
+    media: {
+      file_path: string | null;
+      upload_status?: string | null;
+    } | null;
+  }[];
+  likes?: {
+    count: number;
+  }[];
+}
+
 export interface PostRecord {
   id: number;
   user_id: string;
@@ -164,7 +189,19 @@ export interface Challenge {
     created_at: string;
     post_id: number;
     parent_comment_id?: number | null;
+    media_id?: number;
+    media?: {
+      file_path: string | null;
+    };
+    media_items?: {
+      media_id: number;
+      file_path: string | null;
+      preview_path?: string | null;
+      position: number;
+      is_video?: boolean;
+    }[];
     liked: boolean;
+    likes_count?: number;
     likes?: {
       count: number;
     };

--- a/supabase/migrations/20260528120000_add_comment_media.sql
+++ b/supabase/migrations/20260528120000_add_comment_media.sql
@@ -1,0 +1,76 @@
+ALTER TABLE public.comments
+  ADD COLUMN IF NOT EXISTS media_id bigint REFERENCES public.media(id) ON DELETE SET NULL;
+
+CREATE TABLE IF NOT EXISTS public.comment_media (
+  comment_id integer NOT NULL REFERENCES public.comments(id) ON DELETE CASCADE,
+  media_id bigint NOT NULL REFERENCES public.media(id) ON DELETE CASCADE,
+  position smallint NOT NULL,
+  created_at timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT comment_media_pkey PRIMARY KEY (comment_id, media_id),
+  CONSTRAINT comment_media_comment_position_key UNIQUE (comment_id, position),
+  CONSTRAINT comment_media_position_check CHECK (position >= 0 AND position < 4)
+);
+
+CREATE INDEX IF NOT EXISTS comment_media_media_id_idx
+  ON public.comment_media(media_id);
+
+INSERT INTO public.comment_media (comment_id, media_id, position)
+SELECT id, media_id, 0
+FROM public.comments
+WHERE media_id IS NOT NULL
+ON CONFLICT DO NOTHING;
+
+ALTER TABLE public.comment_media ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "comment_media_select_authenticated"
+  ON public.comment_media FOR SELECT
+  TO authenticated
+  USING (true);
+
+CREATE POLICY "comment_media_insert_comment_owner"
+  ON public.comment_media FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.comments
+      WHERE comments.id = comment_media.comment_id
+        AND comments.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "comment_media_update_comment_owner"
+  ON public.comment_media FOR UPDATE
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.comments
+      WHERE comments.id = comment_media.comment_id
+        AND comments.user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.comments
+      WHERE comments.id = comment_media.comment_id
+        AND comments.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "comment_media_delete_comment_owner"
+  ON public.comment_media FOR DELETE
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.comments
+      WHERE comments.id = comment_media.comment_id
+        AND comments.user_id = auth.uid()
+    )
+  );
+
+GRANT ALL ON TABLE public.comment_media TO anon;
+GRANT ALL ON TABLE public.comment_media TO authenticated;
+GRANT ALL ON TABLE public.comment_media TO service_role;


### PR DESCRIPTION
This PR adds image and video attachments to comments, with the same up-to-4 selection flow as posts and the same background upload behavior after the comment is created.

- Adds comment media support in the app so inline comments and the comments modal can attach, preview, remove, and submit up to four media items.
- Updates comment rendering to show attached media in comment threads, including fullscreen image viewing and video playback.
- Extends the comment data model with a `comment_media` table plus a `comments.media_id` cover reference for compatibility with older clients.
- Reuses the shared media picker and grid behavior so comment attachments follow the same selection and upload flow as post attachments.
- Preserves a simple fallback for textless media comments by storing a short body value that older clients can still render.