### PR TITLE
revert media join tables

### DIFF
--- a/supabase/migrations/20260602232227_revert_post_and_comment_media_tables.sql
+++ b/supabase/migrations/20260602232227_revert_post_and_comment_media_tables.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+-- Revert the multi-media join tables while preserving existing single-media support.
+DROP TABLE IF EXISTS public.post_media;
+DROP TABLE IF EXISTS public.comment_media;
+
+COMMIT;


### PR DESCRIPTION
This PR adds a small cleanup migration that rolls the database back to the single-media shape for posts and comments while keeping the rest of the recent production changes in place.

- Drops the `post_media` and `comment_media` tables through a normal forward migration
- Keeps `comments.media_id` in place, since that column already exists as part of the current schema
- Leaves the side quest pruning migration untouched, so only the media-table rollback is included here