### PR TITLE
localize side quest and post challenge titles

### DIFF
--- a/src/components/Post.tsx
+++ b/src/components/Post.tsx
@@ -64,7 +64,7 @@ interface PostProps {
 }
 
 const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage = false, onPostDeleted }) => {
-  const { t } = useLanguage();
+  const { t, language } = useLanguage();
   const { likedPosts, likeCounts, togglePostLike } = useLikes();
   const { postReactions, togglePostReaction } = useReactions();
   const { user, isAdmin, username: currentUserUsername } = useAuth();
@@ -376,6 +376,7 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
 
   const isChallengePost = !!post.challenge_id;
   const isQuestPost = !!post.quest_id;
+  const challengeTitle = language === "it" ? post.challenge_title_it || post.challenge_title : post.challenge_title;
 
   const handleImageLongPress = async () => {
     try {
@@ -573,7 +574,7 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
               <View style={tagRowStyle}>
                 <Ionicons name="trophy" size={14} color={colors.light.primary} />
                 <Text style={challengeTitleStyle} numberOfLines={1} ellipsizeMode="tail">
-                  <Text style={{ fontWeight: "bold" }}>{t("Challenge:")}</Text> {post.challenge_title}
+                  <Text style={{ fontWeight: "bold" }}>{t("Challenge:")}</Text> {challengeTitle}
                 </Text>
               </View>
             </View>
@@ -707,7 +708,7 @@ const Post: React.FC<PostProps> = ({ post, postUser, setPostCounts, isPostPage =
         <InstagramStoryCard
           ref={storyCardRef}
           username={postUser?.username || "unknown"}
-          challengeTitle={post.challenge_title}
+          challengeTitle={challengeTitle}
           postText={post.body ?? undefined}
           profileImageUrl={profileImageUrl || undefined}
           completionCount={completionCount}

--- a/src/constants/translations.ts
+++ b/src/constants/translations.ts
@@ -439,6 +439,7 @@ export const translations = {
   "A little uncomfortable in a good way": "Un po' scomoda nel modo giusto",
   "What should we steer away from?": "Da cosa dovremmo stare alla larga?",
   "Lots of planning": "Troppa organizzazione",
+  "Talking to strangers": "Parlare con sconosciuti",
   "Going far": "Andare lontano",
   "A month from now, what would make this feel worth it?": "Tra un mese, cosa ti farebbe pensare che ne sia valsa la pena?",
   "I did things I normally would not do": "Ho fatto cose che normalmente non farei",

--- a/src/hooks/useFetchHomeData.ts
+++ b/src/hooks/useFetchHomeData.ts
@@ -266,7 +266,7 @@ export const useFetchHomeData = (sort: FeedSort = "recent") => {
         .from("post")
         .select(`
           *,
-          challenges:challenge_id (title),
+          challenges:challenge_id (title, title_it),
           side_quests:quest_id (title),
           media:media!post_media_id_fkey (file_path),
           likes:likes(count),

--- a/src/hooks/useUserProgress.ts
+++ b/src/hooks/useUserProgress.ts
@@ -29,7 +29,7 @@ const useUserProgress = (targetUserId: string) => {
           media_id,
           challenge_id,
           is_welcome,
-          challenges (title),
+          challenges (title, title_it),
           media:media!post_media_id_fkey (
             file_path,
             upload_status
@@ -48,7 +48,8 @@ const useUserProgress = (targetUserId: string) => {
       // Drop welcome posts from profile feeds
       const transformedPosts = hydratedPosts.map(post => ({
         ...post,
-        challenge_title: post.challenges?.title
+        challenge_title: post.challenges?.title,
+        challenge_title_it: post.challenges?.title_it ?? undefined
       })).filter(post => !post.is_welcome);
 
       // Then fetch like status separately

--- a/src/services/postService.ts
+++ b/src/services/postService.ts
@@ -139,7 +139,8 @@ export function normalizePost(post: PostRecord, likedPosts: Record<number, boole
     comments_count: comments?.length ?? 0,
     liked: likedPosts[post.id] ?? false,
     is_welcome: post.is_welcome ?? null,
-    challenge_title: challenges?.title,
+    challenge_title: challenges?.title ?? post.challenge_title,
+    challenge_title_it: challenges?.title_it ?? post.challenge_title_it,
     quest_title: side_quests?.title,
     comment_previews: getCommentPreviews(post),
   };
@@ -234,7 +235,7 @@ export const postService = {
     blockedUserIds: string[],
     postsPerPage: number = 20
   ): Promise<{ posts: PostRecord[]; hasMore: boolean }> {
-    const select = `${BASE_SELECT}, challenges!inner (title), side_quests:quest_id (title)`;
+    const select = `${BASE_SELECT}, challenges!inner (title, title_it), side_quests:quest_id (title)`;
 
     let query = supabase
       .from("post")
@@ -704,7 +705,7 @@ export const postService = {
     blockedUserIds: string[],
     postsPerPage: number = 20
   ): Promise<{ posts: PostRecord[]; hasMore: boolean }> {
-    const select = `${BASE_SELECT}, challenges:challenge_id (title), side_quests:quest_id (title)`;
+    const select = `${BASE_SELECT}, challenges:challenge_id (title, title_it), side_quests:quest_id (title)`;
 
     let query = supabase
       .from("post")
@@ -782,7 +783,7 @@ export const postService = {
     }
 
     const orderedIds: number[] = idRows.map((r: { post_id: number }) => r.post_id);
-    const select = `${BASE_SELECT}, challenges:challenge_id (title), side_quests:quest_id (title)`;
+    const select = `${BASE_SELECT}, challenges:challenge_id (title, title_it), side_quests:quest_id (title)`;
 
     const { data, error } = await supabase
       .from("post")

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,6 +72,7 @@ export interface PostRecord {
   featured: boolean;
   challenge_id?: number | null;
   challenge_title?: string;
+  challenge_title_it?: string;
   quest_id?: number | null;
   quest_title?: string;
   comfort_zone_rating?: number | null;
@@ -80,7 +81,7 @@ export interface PostRecord {
   }[];
   comments?: PostCommentRecord[];
   profiles?: PostProfileRecord | null;
-  challenges?: { title: string } | null;
+  challenges?: { title: string; title_it?: string | null } | null;
   side_quests?: { title: string } | null;
   is_welcome?: boolean | null;
 }
@@ -119,6 +120,7 @@ export interface Challenge {
     featured: boolean;
     challenge_id?: number | null;
     challenge_title?: string;
+    challenge_title_it?: string;
     quest_id?: number | null;
     quest_title?: string;
     comfort_zone_rating?: number | null;


### PR DESCRIPTION
## summary
- add the missing italian translation for "Talking to strangers" in side quest onboarding
- fetch challenge `title_it` with post challenge joins and carry it through post normalization
- show the localized challenge title in the post challenge badge and instagram story capture

## checks
- `npx eslint src/constants/translations.ts src/types.ts src/services/postService.ts src/components/Post.tsx src/hooks/useFetchHomeData.ts src/hooks/useUserProgress.ts --ext .ts,.tsx`
- `npm run lint` currently fails on existing unrelated repo issues
- `npx tsc --noEmit` currently fails on existing unrelated repo issues