### PR TITLE
reenable media joins

### DIFF
--- a/src/hooks/useMediaUpload.ts
+++ b/src/hooks/useMediaUpload.ts
@@ -9,6 +9,7 @@ import { useLanguage } from '../contexts/LanguageContext';
 import { supabase } from '../lib/supabase';
 import { captureEvent } from '../lib/posthog';
 import { POST_EVENTS } from '../constants/analyticsEvents';
+import { shouldFallbackToLegacyMedia } from '../services/mediaJoinTableSupport';
 
 interface UseMediaUploadOptions {
   onUploadComplete?: () => void;
@@ -159,8 +160,12 @@ export const useMediaUpload = (options: UseMediaUploadOptions = {}): UseMediaUpl
           );
 
         if (postMediaError) {
-          await supabase.from('post').delete().eq('id', postData.id);
-          throw postMediaError;
+          if (shouldFallbackToLegacyMedia(postMediaError, mediaItems.length)) {
+            console.warn('post_media unavailable, falling back to legacy post.media_id support');
+          } else {
+            await supabase.from('post').delete().eq('id', postData.id);
+            throw postMediaError;
+          }
         }
       }
 

--- a/src/services/backgroundUploadService.ts
+++ b/src/services/backgroundUploadService.ts
@@ -18,6 +18,19 @@ class BackgroundUploadService {
   private maxRetries = 3;
   private maxConcurrentUploads = 2;
 
+  private scheduleNextProcessing() {
+    if (this.uploadQueue.length === 0) {
+      if (this.activeUploads.size === 0) {
+        this.isProcessing = false;
+        console.log('Upload queue processing completed');
+      }
+      return;
+    }
+
+    this.isProcessing = false;
+    setTimeout(() => this.processQueue(), 100);
+  }
+
   // Add an upload to the queue
   addToQueue(
     mediaId: number,
@@ -85,14 +98,7 @@ class BackgroundUploadService {
       // Process upload without blocking the queue
       this.processUpload(item).finally(() => {
         this.activeUploads.delete(item.id);
-        
-        // Continue processing if there are more items
-        if (this.uploadQueue.length > 0) {
-          setTimeout(() => this.processQueue(), 100);
-        } else if (this.activeUploads.size === 0) {
-          this.isProcessing = false;
-          console.log('Upload queue processing completed');
-        }
+        this.scheduleNextProcessing();
       });
     }
 

--- a/src/services/commentService.ts
+++ b/src/services/commentService.ts
@@ -1,5 +1,6 @@
 import { supabase } from "../lib/supabase";
 import { imageService } from "./imageService";
+import { shouldFallbackToLegacyMedia } from "./mediaJoinTableSupport";
 import { Comment, CommentRecord } from "../types";
 import { MediaSelectionResult } from "../utils/handleMediaUpload";
 
@@ -187,6 +188,8 @@ export const commentService = {
 
     if (error) throw error;
 
+    let fellBackToLegacyMedia = false;
+
     if (mediaItems.length > 0) {
       const { error: commentMediaError } = await supabase
         .from("comment_media")
@@ -198,15 +201,27 @@ export const commentService = {
           }))
         );
 
-      if (commentMediaError) throw commentMediaError;
+      if (commentMediaError) {
+        if (shouldFallbackToLegacyMedia(commentMediaError, mediaItems.length)) {
+          fellBackToLegacyMedia = true;
+          console.warn('comment_media unavailable, falling back to legacy comments.media_id support');
+        } else {
+          await supabase.from("comments").delete().eq("id", data.id);
+          throw commentMediaError;
+        }
+      }
     }
 
     const comment = formatComment(data as CommentRecord);
     if (mediaItems.length === 0) return comment;
 
+    const resolvedMediaItems = fellBackToLegacyMedia
+      ? mediaItems.slice(0, 1)
+      : mediaItems;
+
     return {
       ...comment,
-      media_items: mediaItems.map((item, index) => ({
+      media_items: resolvedMediaItems.map((item, index) => ({
         media_id: item.mediaId,
         file_path: item.isVideo ? item.pendingUpload.originalUri : item.previewUrl,
         preview_path: item.thumbnailUri || item.previewUrl,

--- a/src/services/mediaJoinTableSupport.ts
+++ b/src/services/mediaJoinTableSupport.ts
@@ -1,0 +1,16 @@
+const MISSING_RELATION_CODE = "42P01";
+
+type SupabaseErrorShape = {
+  code?: string;
+  message?: string;
+};
+
+function isMissingRelationError(error: SupabaseErrorShape | null | undefined) {
+  return error?.code === MISSING_RELATION_CODE ||
+    error?.message?.includes('relation "post_media" does not exist') ||
+    error?.message?.includes('relation "comment_media" does not exist');
+}
+
+export function shouldFallbackToLegacyMedia(error: SupabaseErrorShape | null | undefined, mediaCount: number) {
+  return mediaCount === 1 && isMissingRelationError(error);
+}

--- a/supabase/migrations/20260711120000_reenable_post_and_comment_media.sql
+++ b/supabase/migrations/20260711120000_reenable_post_and_comment_media.sql
@@ -1,0 +1,250 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.post_media (
+  post_id integer NOT NULL REFERENCES public.post(id) ON DELETE CASCADE,
+  media_id bigint NOT NULL REFERENCES public.media(id) ON DELETE CASCADE,
+  position smallint NOT NULL,
+  created_at timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT post_media_pkey PRIMARY KEY (post_id, media_id),
+  CONSTRAINT post_media_post_position_key UNIQUE (post_id, position),
+  CONSTRAINT post_media_position_check CHECK (position >= 0 AND position < 4)
+);
+
+CREATE INDEX IF NOT EXISTS post_media_media_id_idx
+  ON public.post_media(media_id);
+
+INSERT INTO public.post_media (post_id, media_id, position)
+SELECT id, media_id, 0
+FROM public.post
+WHERE media_id IS NOT NULL
+ON CONFLICT DO NOTHING;
+
+ALTER TABLE public.post_media ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'post_media'
+      AND policyname = 'post_media_select_authenticated'
+  ) THEN
+    CREATE POLICY "post_media_select_authenticated"
+      ON public.post_media FOR SELECT
+      TO authenticated
+      USING (true);
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'post_media'
+      AND policyname = 'post_media_insert_post_owner'
+  ) THEN
+    CREATE POLICY "post_media_insert_post_owner"
+      ON public.post_media FOR INSERT
+      TO authenticated
+      WITH CHECK (
+        EXISTS (
+          SELECT 1
+          FROM public.post
+          WHERE post.id = post_media.post_id
+            AND post.user_id = auth.uid()
+        )
+      );
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'post_media'
+      AND policyname = 'post_media_update_post_owner'
+  ) THEN
+    CREATE POLICY "post_media_update_post_owner"
+      ON public.post_media FOR UPDATE
+      TO authenticated
+      USING (
+        EXISTS (
+          SELECT 1
+          FROM public.post
+          WHERE post.id = post_media.post_id
+            AND post.user_id = auth.uid()
+        )
+      )
+      WITH CHECK (
+        EXISTS (
+          SELECT 1
+          FROM public.post
+          WHERE post.id = post_media.post_id
+            AND post.user_id = auth.uid()
+        )
+      );
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'post_media'
+      AND policyname = 'post_media_delete_post_owner'
+  ) THEN
+    CREATE POLICY "post_media_delete_post_owner"
+      ON public.post_media FOR DELETE
+      TO authenticated
+      USING (
+        EXISTS (
+          SELECT 1
+          FROM public.post
+          WHERE post.id = post_media.post_id
+            AND post.user_id = auth.uid()
+        )
+      );
+  END IF;
+END
+$$;
+
+GRANT ALL ON TABLE public.post_media TO anon;
+GRANT ALL ON TABLE public.post_media TO authenticated;
+GRANT ALL ON TABLE public.post_media TO service_role;
+
+ALTER TABLE public.comments
+  ADD COLUMN IF NOT EXISTS media_id bigint REFERENCES public.media(id) ON DELETE SET NULL;
+
+CREATE TABLE IF NOT EXISTS public.comment_media (
+  comment_id integer NOT NULL REFERENCES public.comments(id) ON DELETE CASCADE,
+  media_id bigint NOT NULL REFERENCES public.media(id) ON DELETE CASCADE,
+  position smallint NOT NULL,
+  created_at timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT comment_media_pkey PRIMARY KEY (comment_id, media_id),
+  CONSTRAINT comment_media_comment_position_key UNIQUE (comment_id, position),
+  CONSTRAINT comment_media_position_check CHECK (position >= 0 AND position < 4)
+);
+
+CREATE INDEX IF NOT EXISTS comment_media_media_id_idx
+  ON public.comment_media(media_id);
+
+INSERT INTO public.comment_media (comment_id, media_id, position)
+SELECT id, media_id, 0
+FROM public.comments
+WHERE media_id IS NOT NULL
+ON CONFLICT DO NOTHING;
+
+ALTER TABLE public.comment_media ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'comment_media'
+      AND policyname = 'comment_media_select_authenticated'
+  ) THEN
+    CREATE POLICY "comment_media_select_authenticated"
+      ON public.comment_media FOR SELECT
+      TO authenticated
+      USING (true);
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'comment_media'
+      AND policyname = 'comment_media_insert_comment_owner'
+  ) THEN
+    CREATE POLICY "comment_media_insert_comment_owner"
+      ON public.comment_media FOR INSERT
+      TO authenticated
+      WITH CHECK (
+        EXISTS (
+          SELECT 1
+          FROM public.comments
+          WHERE comments.id = comment_media.comment_id
+            AND comments.user_id = auth.uid()
+        )
+      );
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'comment_media'
+      AND policyname = 'comment_media_update_comment_owner'
+  ) THEN
+    CREATE POLICY "comment_media_update_comment_owner"
+      ON public.comment_media FOR UPDATE
+      TO authenticated
+      USING (
+        EXISTS (
+          SELECT 1
+          FROM public.comments
+          WHERE comments.id = comment_media.comment_id
+            AND comments.user_id = auth.uid()
+        )
+      )
+      WITH CHECK (
+        EXISTS (
+          SELECT 1
+          FROM public.comments
+          WHERE comments.id = comment_media.comment_id
+            AND comments.user_id = auth.uid()
+        )
+      );
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'comment_media'
+      AND policyname = 'comment_media_delete_comment_owner'
+  ) THEN
+    CREATE POLICY "comment_media_delete_comment_owner"
+      ON public.comment_media FOR DELETE
+      TO authenticated
+      USING (
+        EXISTS (
+          SELECT 1
+          FROM public.comments
+          WHERE comments.id = comment_media.comment_id
+            AND comments.user_id = auth.uid()
+        )
+      );
+  END IF;
+END
+$$;
+
+GRANT ALL ON TABLE public.comment_media TO anon;
+GRANT ALL ON TABLE public.comment_media TO authenticated;
+GRANT ALL ON TABLE public.comment_media TO service_role;
+
+COMMIT;


### PR DESCRIPTION
This PR brings multi-image post and comment attachments back into the app, restores the supporting database tables, and fixes the upload queue behavior so all selected media finish uploading in order.

- Adds a new migration that recreates post_media and comment_media, with backfills from the legacy media_id columns and the original access policies.
- Keeps older app versions compatible by continuing to save the first attachment on the existing post and comment media fields.
- Updates post and comment creation to fall back to legacy single-media writes when an environment is temporarily missing the join tables.
- Fixes the background media queue so multi-image posts keep processing the remaining uploads instead of leaving later attachments stuck in pending.