### PR TITLE
rename media join tables

### DIFF
--- a/supabase/migrations/20260712003000_rename_media_join_tables_for_backward_compat.sql
+++ b/supabase/migrations/20260712003000_rename_media_join_tables_for_backward_compat.sql
@@ -1,0 +1,15 @@
+BEGIN;
+
+ALTER TABLE IF EXISTS public.post_media
+  RENAME TO post_media_items;
+
+ALTER TABLE IF EXISTS public.comment_media
+  RENAME TO comment_media_items;
+
+ALTER INDEX IF EXISTS public.post_media_media_id_idx
+  RENAME TO post_media_items_media_id_idx;
+
+ALTER INDEX IF EXISTS public.comment_media_media_id_idx
+  RENAME TO comment_media_items_media_id_idx;
+
+COMMIT;

--- a/supabase/migrations/20260712004500_break_postgrest_many_to_many_inference.sql
+++ b/supabase/migrations/20260712004500_break_postgrest_many_to_many_inference.sql
@@ -1,0 +1,57 @@
+BEGIN;
+
+CREATE SEQUENCE IF NOT EXISTS public.post_media_items_id_seq;
+
+ALTER TABLE public.post_media_items
+  ADD COLUMN IF NOT EXISTS id bigint;
+
+ALTER TABLE public.post_media_items
+  ALTER COLUMN id SET DEFAULT nextval('public.post_media_items_id_seq');
+
+UPDATE public.post_media_items
+SET id = nextval('public.post_media_items_id_seq')
+WHERE id IS NULL;
+
+ALTER TABLE public.post_media_items
+  ALTER COLUMN id SET NOT NULL;
+
+ALTER TABLE public.post_media_items
+  DROP CONSTRAINT IF EXISTS post_media_pkey;
+
+ALTER TABLE public.post_media_items
+  ADD CONSTRAINT post_media_items_pkey PRIMARY KEY (id);
+
+ALTER TABLE public.post_media_items
+  ADD CONSTRAINT post_media_items_post_media_key UNIQUE (post_id, media_id);
+
+ALTER SEQUENCE public.post_media_items_id_seq
+  OWNED BY public.post_media_items.id;
+
+CREATE SEQUENCE IF NOT EXISTS public.comment_media_items_id_seq;
+
+ALTER TABLE public.comment_media_items
+  ADD COLUMN IF NOT EXISTS id bigint;
+
+ALTER TABLE public.comment_media_items
+  ALTER COLUMN id SET DEFAULT nextval('public.comment_media_items_id_seq');
+
+UPDATE public.comment_media_items
+SET id = nextval('public.comment_media_items_id_seq')
+WHERE id IS NULL;
+
+ALTER TABLE public.comment_media_items
+  ALTER COLUMN id SET NOT NULL;
+
+ALTER TABLE public.comment_media_items
+  DROP CONSTRAINT IF EXISTS comment_media_pkey;
+
+ALTER TABLE public.comment_media_items
+  ADD CONSTRAINT comment_media_items_pkey PRIMARY KEY (id);
+
+ALTER TABLE public.comment_media_items
+  ADD CONSTRAINT comment_media_items_comment_media_key UNIQUE (comment_id, media_id);
+
+ALTER SEQUENCE public.comment_media_items_id_seq
+  OWNED BY public.comment_media_items.id;
+
+COMMIT;


### PR DESCRIPTION
This PR is a migration-only compatibility fix for older clients that are still querying posts and comments through the legacy media relationship shape.

- Renames post_media to post_media_items and comment_media to comment_media_items.
- Preserves the existing rows and supporting indexes while removing the table names that PostgREST was treating as an additional post-to-media and comment-to-media embedding path.
- Keeps the legacy post.media_id and comments.media_id relationships unchanged so older clients can keep loading the home feed and profile data while we sort out OTA update delivery.