### PR TITLE
align media table names

### DIFF
--- a/src/hooks/useMediaUpload.ts
+++ b/src/hooks/useMediaUpload.ts
@@ -150,7 +150,7 @@ export const useMediaUpload = (options: UseMediaUploadOptions = {}): UseMediaUpl
 
       if (mediaItems.length > 0) {
         const { error: postMediaError } = await supabase
-          .from('post_media')
+          .from('post_media_items')
           .insert(
             mediaItems.map((item, index) => ({
               post_id: postData.id,

--- a/src/services/commentService.ts
+++ b/src/services/commentService.ts
@@ -84,7 +84,7 @@ export const commentService = {
 
     try {
       const { data, error } = await supabase
-        .from("comment_media")
+        .from("comment_media_items")
         .select("comment_id, media_id, position, media (file_path, upload_status)")
         .in("comment_id", commentIds);
 
@@ -192,7 +192,7 @@ export const commentService = {
 
     if (mediaItems.length > 0) {
       const { error: commentMediaError } = await supabase
-        .from("comment_media")
+        .from("comment_media_items")
         .insert(
           mediaItems.map((item, index) => ({
             comment_id: data.id,

--- a/src/services/mediaJoinTableSupport.ts
+++ b/src/services/mediaJoinTableSupport.ts
@@ -8,7 +8,9 @@ type SupabaseErrorShape = {
 function isMissingRelationError(error: SupabaseErrorShape | null | undefined) {
   return error?.code === MISSING_RELATION_CODE ||
     error?.message?.includes('relation "post_media" does not exist') ||
-    error?.message?.includes('relation "comment_media" does not exist');
+    error?.message?.includes('relation "comment_media" does not exist') ||
+    error?.message?.includes('relation "post_media_items" does not exist') ||
+    error?.message?.includes('relation "comment_media_items" does not exist');
 }
 
 export function shouldFallbackToLegacyMedia(error: SupabaseErrorShape | null | undefined, mediaCount: number) {

--- a/src/services/postService.ts
+++ b/src/services/postService.ts
@@ -195,7 +195,7 @@ export async function hydratePostMedia(posts: PostRecord[]): Promise<PostRecord[
 
   try {
     const { data, error } = await supabase
-      .from("post_media")
+      .from("post_media_items")
       .select("post_id, media_id, position, media (file_path, upload_status)")
       .in("post_id", postIds);
 


### PR DESCRIPTION
This PR is the code-side follow-up to the merged media compatibility migrations.

- Updates the app queries and writes that still referenced post_media and comment_media to use post_media_items and comment_media_items.
- Keeps the legacy post.media_id and comments.media_id paths unchanged.
- Extends the temporary fallback detection so environments missing either the old or new join-table names still degrade to legacy single-media behavior.