### PR TITLE
Add EAS Workflows for OTA updates and native builds

### DIFF
--- a/.eas/workflows/build-and-submit-ios.yml
+++ b/.eas/workflows/build-and-submit-ios.yml
@@ -1,0 +1,50 @@
+# Full native build + TestFlight submission for iOS.
+#
+# MANUAL trigger only (no `on:` block) — run it from the Expo dashboard
+# (Workflows -> Run) or:
+#   eas workflow:run .eas/workflows/build-and-submit-ios.yml
+#
+# Use this when you have NATIVE changes that an OTA update can't ship:
+#   - new native dependencies
+#   - changes to app.json native config / config plugins
+#   - Expo SDK upgrades
+#   - a marketing-version bump (ios/StepnOut/Info.plist CFBundleShortVersionString)
+#
+# JS-only changes do NOT need this — they ship automatically via
+# publish-production-update.yml when you merge to main.
+
+name: Build & submit production (iOS)
+
+jobs:
+  verify_env:
+    name: Verify required env vars
+    environment: production
+    steps:
+      - name: Ensure required EXPO_PUBLIC_* vars are present
+        run: |
+          missing=0
+          for v in EXPO_PUBLIC_SUPABASE_URL EXPO_PUBLIC_SUPABASE_ANON_KEY EXPO_PUBLIC_POSTHOG_API_KEY; do
+            if [ -z "$(printenv "$v")" ]; then echo "❌ Missing $v"; missing=1; fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            echo "Aborting: required production env vars are missing in EAS."
+            exit 1
+          fi
+          echo "✅ All required env vars present"
+
+  build_ios:
+    name: Build iOS (production)
+    needs: [verify_env]
+    type: build
+    params:
+      platform: ios
+      profile: production
+
+  submit_ios:
+    name: Submit to TestFlight
+    needs: [build_ios]
+    type: submit
+    params:
+      platform: ios
+      profile: production
+      build_id: ${{ needs.build_ios.outputs.build_id }}

--- a/.eas/workflows/publish-production-update.yml
+++ b/.eas/workflows/publish-production-update.yml
@@ -40,4 +40,7 @@ jobs:
       - uses: eas/checkout
       - uses: eas/install_node_modules
       - name: Publish update
-        run: eas update --branch production --environment production --message "CI OTA from main" --non-interactive
+        # Label the update with the latest commit subject so entries in
+        # `eas update:list` are identifiable (delivery is keyed on update ID,
+        # not the message, but a readable label makes rollbacks/debugging easy).
+        run: eas update --branch production --environment production --message "$(git log -1 --pretty=%s)" --non-interactive

--- a/.eas/workflows/publish-production-update.yml
+++ b/.eas/workflows/publish-production-update.yml
@@ -1,8 +1,12 @@
 # Ships JS / asset changes to production over-the-air (OTA).
 #
-# Runs AUTOMATICALLY every time you merge to `main`, and can also be run
-# on demand from the Expo dashboard (Workflows -> Run) or:
+# MANUAL trigger only — nothing deploys automatically. Run it yourself from
+# the Expo dashboard (Workflows -> Run) or:
 #   eas workflow:run .eas/workflows/publish-production-update.yml
+#
+# Only use this for JS-only changes. If a change touches native code
+# (new native deps, app.json native config, SDK bump), use
+# build-and-submit-ios.yml instead — an OTA can't ship native changes.
 #
 # Why this is reliable: it runs on EAS servers using the EAS "production"
 # environment variables — never your local .env — so the local-dev Supabase
@@ -10,10 +14,6 @@
 # in `verify_env` instead of crashing on users' phones.
 
 name: Publish production update
-
-on:
-  push:
-    branches: ['main']
 
 jobs:
   verify_env:

--- a/.eas/workflows/publish-production-update.yml
+++ b/.eas/workflows/publish-production-update.yml
@@ -1,0 +1,43 @@
+# Ships JS / asset changes to production over-the-air (OTA).
+#
+# Runs AUTOMATICALLY every time you merge to `main`, and can also be run
+# on demand from the Expo dashboard (Workflows -> Run) or:
+#   eas workflow:run .eas/workflows/publish-production-update.yml
+#
+# Why this is reliable: it runs on EAS servers using the EAS "production"
+# environment variables — never your local .env — so the local-dev Supabase
+# URL/key can't leak into a production bundle, and a missing key fails loudly
+# in `verify_env` instead of crashing on users' phones.
+
+name: Publish production update
+
+on:
+  push:
+    branches: ['main']
+
+jobs:
+  verify_env:
+    name: Verify required env vars
+    environment: production
+    steps:
+      - name: Ensure required EXPO_PUBLIC_* vars are present
+        run: |
+          missing=0
+          for v in EXPO_PUBLIC_SUPABASE_URL EXPO_PUBLIC_SUPABASE_ANON_KEY EXPO_PUBLIC_POSTHOG_API_KEY; do
+            if [ -z "$(printenv "$v")" ]; then echo "❌ Missing $v"; missing=1; fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            echo "Aborting: required production env vars are missing in EAS."
+            exit 1
+          fi
+          echo "✅ All required env vars present"
+
+  publish_update:
+    name: Publish OTA to production
+    needs: [verify_env]
+    environment: production
+    steps:
+      - uses: eas/checkout
+      - uses: eas/install_node_modules
+      - name: Publish update
+        run: eas update --branch production --environment production --message "CI OTA from main" --non-interactive


### PR DESCRIPTION
## What
Adds two **manual-only** EAS Workflows so builds and OTA updates are reliable, reproducible, and run on EAS servers (never local `.env`).

| Workflow | Trigger | Purpose |
|---|---|---|
| `publish-production-update.yml` | manual | Publish OTA to production (`--environment production` baked in) for JS/asset-only changes |
| `build-and-submit-ios.yml` | manual | Full native build → TestFlight, for native changes / version bumps |

## Why
Tonight's production crash was caused by `EXPO_PUBLIC_SUPABASE_ANON_KEY` being missing from EAS env vars — builds/OTAs got `undefined` and crashed at launch. Both workflows start with a **`verify_env` gate** that fails loudly in CI if a required `EXPO_PUBLIC_*` var is missing, instead of shipping a crashing bundle.

## Notes
- Nothing auto-deploys — you trigger each run yourself (Expo dashboard → Workflows → Run, or `eas workflow:run`).
- Runs on EAS servers with the production environment, so the local-dev Supabase URL/key can't leak into a prod bundle.
- Both files pass `eas workflow:validate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)