### PR TITLE
Add missing Italian translations for side quest flow

### DIFF
--- a/src/constants/translations.ts
+++ b/src/constants/translations.ts
@@ -114,6 +114,7 @@ export const translations = {
   "You stepped out!": "Sei uscito dalla tua zona!",
   "Bravo!": "Bravo!",
   "(count) people": "(count) persone",
+  people: "persone",
   "have stepped out of their comfort zone this week.":
     "sono uscite dalla loro zona di comfort questa settimana.",
   "Inspire your friend to be the (count)th!": "Ispira il tuo amico ad essere il (count)°!",
@@ -452,6 +453,7 @@ export const translations = {
   Reflective: "Riflessiva",
   "Choose all that apply": "Scegli tutte quelle che si applicano",
   "Spending money": "Spendere soldi",
+  "Talking to strangers": "Parlare con sconosciuti",
   "Group/social situations": "Situazioni di gruppo/sociali",
   "Physically demanding activities": "Attività fisicamente impegnative",
   "Nighttime activities": "Attività notturne",


### PR DESCRIPTION
## What

Adds two missing Italian translations surfaced in the side quest experience:

- **`"Talking to strangers"`** → `"Parlare con sconosciuti"` — the "avoid" option in the side quest questionnaire. It was the only avoid-option without an `it` entry, so it rendered in English.
- **`people`** → `"persone"` — the bare count unit in the completion celebration modal (e.g. "42 people" → "42 persone"). The modal uses `t('people')`, and only the distinct `"(count) people"` key existed.

## Why

Both strings render via `t(...)` but had no entry in `src/constants/translations.ts`, so Italian users saw English text.

## Testing

Verified against `SideQuestQuestionnaire.tsx` (`t(option.label)`) and `CompletionCelebrationModal.tsx` (`countUnit: t('people')`). Confirmed all sibling strings in both flows were already translated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)