### PR TITLE
Hide enable-notifications banner on Android

### DIFF
--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -186,6 +186,12 @@ function RootLayoutNav() {
 
       if (!session?.user?.id || loading) return;
 
+      // Only prompt to enable notifications on iOS; hide the banner on Android.
+      if (Platform.OS === 'android') {
+        setShowNotificationsBanner(false);
+        return;
+      }
+
       const isAuthRoute =
         pathname === '/login' ||
         pathname === '/register' ||


### PR DESCRIPTION
## What

Hides the home-screen banner that prompts users to *"Enable notifications"* when the app is running on **Android**. It continues to show on iOS as before.

## How

Added an early `Platform.OS === 'android'` guard at the top of `maybeShowNotificationsBanner` in `src/app/_layout.tsx`. On Android it sets the banner hidden and returns before any permission checks run, so no unnecessary `Notifications.getPermissionsAsync()` call or banner render happens.

```ts
// Only prompt to enable notifications on iOS; hide the banner on Android.
if (Platform.OS === 'android') {
  setShowNotificationsBanner(false);
  return;
}
```

## Testing

- iOS: banner behavior unchanged (still shown when permission not granted / no push token).
- Android: banner no longer appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)