### PR TITLE
Fix OTA export failure by restricting platforms to ios/android

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,6 +3,7 @@
     "name": "StepnOut",
     "slug": "stepnout",
     "version": "2.3.0",
+    "platforms": ["ios", "android"],
     "orientation": "portrait",
     "scheme": "com.patrickgousseau.stepnout",
     "userInterfaceStyle": "automatic",


### PR DESCRIPTION
## Problem

The `Publish production update` EAS workflow errored during export:

```
Unable to resolve module react-native-web-webview from
node_modules/react-native-youtube-iframe/lib/commonjs/WebView.web.js
✖ Export failed
```

The workflow runs `expo export --platform=all`. Since `app.json` had no `platforms` key, Expo defaulted to bundling **web** as well. The web build resolves `react-native-youtube-iframe`'s `.web.js` variant (used via `PieceCard.tsx`), which `require`s `react-native-web-webview` — a package that isn't installed. Web bundling failed and aborted the entire update.

The workflow's `platform: ios` param only filters what gets *published*, not what gets *exported*, so it couldn't prevent this.

## Fix

Add `"platforms": ["ios", "android"]` to `app.json` so Expo never bundles web. The app is native-only and OTAs ship to iOS, so web was unused (and already unbuildable due to the missing dep).

## Verification

Ran a full `CI=1 npx expo export --platform all` locally — now produces only ios + android bundles and completes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)