### PR TITLE
Fix infinite loading after long background (Supabase token-refresh hang)

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,5 +1,4 @@
-import React, { createContext, useContext, useEffect, useState, useRef } from "react";
-import { AppState, AppStateStatus } from "react-native";
+import React, { createContext, useContext, useEffect, useState } from "react";
 import * as Linking from 'expo-linking';
 import { router } from 'expo-router';
 import { Session } from "@supabase/supabase-js";
@@ -50,7 +49,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [loading, setLoading] = useState(true);
   const [isAdmin, setIsAdmin] = useState(false);
   const [username, setUsername] = useState<string | null>(null);
-  const appState = useRef(AppState.currentState);
 
   useEffect(() => {
     let authSubscription: { unsubscribe: () => void } | null = null;
@@ -165,25 +163,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     };
   }, []);
 
-  // Handle app state changes - refresh session when returning from background
-  useEffect(() => {
-    const handleAppStateChange = async (nextAppState: AppStateStatus) => {
-      if (
-        appState.current.match(/inactive|background/) &&
-        nextAppState === "active"
-      ) {
-        // Refresh session when app returns from background
-        const { data: { session: refreshedSession } } = await supabase.auth.getSession();
-        if (refreshedSession) {
-          setSession(refreshedSession);
-        }
-      }
-      appState.current = nextAppState;
-    };
-
-    const subscription = AppState.addEventListener("change", handleAppStateChange);
-    return () => subscription.remove();
-  }, []);
+  // Session refresh on foreground is handled centrally in src/lib/supabase.ts
+  // via supabase.auth.startAutoRefresh()/stopAutoRefresh() wired to AppState.
+  // onAuthStateChange above keeps `session` in sync when the token is refreshed,
+  // so we no longer call getSession() here (which could itself hang on a wedged
+  // refresh and defeat the purpose).
 
   // Helper: Check if username is taken
   const checkUsernameAvailable = async (username: string, excludeUserId?: string) => {

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,5 +1,6 @@
 import 'react-native-url-polyfill/auto';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { AppState } from 'react-native';
 import { createClient } from '@supabase/supabase-js';
 
 const AsyncStorageAdapter = {
@@ -12,6 +13,21 @@ export const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL!;
 export const supabaseAnonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY!;
 export const supabaseStorageUrl = `${supabaseUrl}/storage/v1/object/public/challenge-uploads`;
 
+// Hard timeout on every request. Without this, a token-refresh fetch that
+// stalls on app resume (e.g. network still waking from suspension) never
+// resolves or rejects. supabase-js de-dupes refreshes onto a single shared
+// promise, so that one dead fetch wedges getSession() — and therefore every
+// query — until the app is force-killed. The AbortController guarantees the
+// stuck request fails instead of hanging forever, releasing the client.
+const REQUEST_TIMEOUT_MS = 15000;
+const fetchWithTimeout = (input: RequestInfo | URL, init?: RequestInit) => {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  return fetch(input, { ...init, signal: controller.signal }).finally(() =>
+    clearTimeout(timeout)
+  );
+};
+
 export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
   auth: {
     storage: AsyncStorageAdapter,
@@ -19,6 +35,22 @@ export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
     persistSession: true,
     detectSessionInUrl: false,
   },
+  global: {
+    fetch: fetchWithTimeout,
+  },
+});
+
+// Supabase's required React Native pattern: the auto-refresh timer is a JS
+// setInterval, which the OS freezes while the app is backgrounded. Driving it
+// off AppState means we do exactly one clean refresh on foreground and stop the
+// timer while backgrounded, instead of leaving it to fire a doomed refresh at
+// an arbitrary moment during resume.
+AppState.addEventListener('change', (state) => {
+  if (state === 'active') {
+    supabase.auth.startAutoRefresh();
+  } else {
+    supabase.auth.stopAutoRefresh();
+  }
 });
 
 export const initializeSupabase = async () => {


### PR DESCRIPTION
## Problem

After the app was backgrounded for several hours, pull-to-refresh (and any other query) would spin **forever**, and the only fix was force-quitting and reopening the app.

## Root cause

A wedged Supabase token refresh:

1. **Missing RN auto-refresh lifecycle wiring.** We set `autoRefreshToken: true` but never wired the React-Native-required `startAutoRefresh()`/`stopAutoRefresh()` to `AppState`. Auto-refresh runs on a JS `setInterval`, which the OS freezes while the app is backgrounded — so the 1h access token expired and the timer could fire a doomed refresh at a bad moment on resume.
2. **No request timeout.** The refresh `fetch` had no timeout. `supabase-js` de-dupes concurrent refreshes onto a single shared promise (`refreshingDeferred`), and *every* query routes through `getSession()` → that promise. So one stalled refresh (network still waking on resume) wedged the entire client until the in-memory promise was cleared — i.e. an app restart. That's exactly why only a force-quit fixed it.

## Changes

- **`src/lib/supabase.ts`**
  - Add a 15s `AbortController` timeout as the client's `global.fetch`, so a stalled request fails and releases the client instead of hanging forever.
  - Wire `startAutoRefresh()`/`stopAutoRefresh()` to `AppState` at module scope, per the [official Supabase React Native quickstart](https://supabase.com/docs/guides/auth/quickstarts/react-native).
- **`src/contexts/AuthContext.tsx`**
  - Remove the now-redundant manual `getSession()` on foreground (and its unused `AppState` import + ref). Refresh is handled centrally; `onAuthStateChange` keeps `session` in sync.

## Conventions

This brings the client in line with the documented Supabase RN auth pattern (the `startAutoRefresh`/`stopAutoRefresh` wiring was the missing required piece), plus one hardening addition the docs omit (the fetch timeout).

## Testing notes

- Hard to reproduce the original 12h-background wedge on demand. To sanity-check the safety net, temporarily set `REQUEST_TIMEOUT_MS = 1` and confirm queries **error out gracefully** (spinner stops) instead of hanging, then revert to `15000`.
- Follow-up worth confirming: the home feed's `isError` state should show a retry affordance, since a stalled refresh now surfaces as an error rather than an infinite spinner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)