### PR TITLE
Fix quest title overflowing its pill in the home feed

### DIFF
--- a/src/components/Post.tsx
+++ b/src/components/Post.tsx
@@ -964,6 +964,7 @@ const challengeTitleStyle: TextStyle = {
 const questTitleStyle: TextStyle = {
   color: colors.sideQuest.text,
   fontSize: 13,
+  flex: 1,
 };
 
 const containerStyle: ViewStyle = {


### PR DESCRIPTION
## Problem

In the home feed, when a post shows the side quest the user completed, a long quest title spills past the rounded pill's border instead of truncating.

## Cause

The quest tag `<Text>` already had `numberOfLines={1}` and `ellipsizeMode="tail"`, but inside its flex row (`tagRowStyle`) it had no `flex`/`flexShrink`. So it sized to its full content width and overflowed the pill — the ellipsis never got a chance to apply.

## Fix

Add `flex: 1` to `questTitleStyle` so the text shrinks to the available width and truncates with `…`.

## Note

The **challenge** pill directly above uses the same row pattern and has the same latent issue (just hasn't surfaced because challenge titles are shorter). Left out of this PR to keep it scoped to the reported bug — happy to follow up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)