### PR TITLE
fix recently active rotation

### DIFF
--- a/supabase/migrations/20260724040000_fix_recently_active_rotation.sql
+++ b/supabase/migrations/20260724040000_fix_recently_active_rotation.sql
@@ -1,0 +1,22 @@
+CREATE INDEX IF NOT EXISTS post_user_id_created_at_idx
+  ON public.post (user_id, created_at DESC);
+
+CREATE OR REPLACE FUNCTION "public"."rotate_recently_active_real"() RETURNS "void"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    AS $$
+  BEGIN
+    UPDATE public.profiles
+    SET is_recently_active = false
+    WHERE is_recently_active = true;
+
+    UPDATE public.profiles p
+    SET is_recently_active = true
+    WHERE coalesce(p.last_open_at, p.created_at) >= now() - interval '24 hours'
+      OR EXISTS (
+        SELECT 1
+        FROM public.post po
+        WHERE po.user_id = p.id
+          AND po.created_at >= now() - interval '24 hours'
+      );
+  END;
+  $$;


### PR DESCRIPTION
## what
- update recently-active rotation to use profiles.last_open_at and posts from the last 24 hours
- add an index for recent post lookups by user

## why
- the old function used auth.sessions.updated_at, so users like shwayyy could open the app/post recently but still be excluded from the banner count

## verification
- checked production readonly data: shwayyy last_open_at is 2026-07-24 02:19 utc and latest post is 2026-07-23 22:00 utc, while is_recently_active was false
- the replacement activity query currently returns 14 users total, 10 with profile photos