### PR TITLE
Personalized side quest intake flow

### DIFF
--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -91,8 +91,13 @@ function RootLayoutNav() {
     pathname.includes('/esplora/category/') ||
     pathname === '/esplora/saved';
 
+  // The personalized quest intake is a self-contained flow with its own close
+  // button and progress bar, so it renders without any global chrome.
+  const isPersonalizedQuestFlow = pathname.includes('/personalized-quest/');
+
   // hide logo on auth screens
   const hideLogo =
+    isPersonalizedQuestFlow ||
     pathname === '/login' ||
     pathname === '/register' ||
     pathname === '/forgot-password' ||
@@ -390,7 +395,7 @@ function RootLayoutNav() {
       onLayout={onLayoutRootView}
     >
       <StatusBar backgroundColor={colors.light.background} style="dark" />
-      {!isEsploraDetail && (
+      {!isEsploraDetail && !isPersonalizedQuestFlow && (
         <Header
           onNotificationPress={handleNotificationPress}
           onMenuPress={handleMenuPress}
@@ -464,6 +469,15 @@ function RootLayoutNav() {
             // edge-only swipe so it doesn't steal horizontal gestures from PagerView
             fullScreenGestureEnabled: false,
             gestureResponseDistance: 24,
+          }}
+        />
+        <Stack.Screen
+          name="personalized-quest/intake"
+          options={{
+            headerShown: false,
+            // A back-swipe mid-intake would silently drop the answers, so the
+            // flow is left via its own Close button.
+            gestureEnabled: false,
           }}
         />
       </Stack>

--- a/src/app/personalized-quest/intake.tsx
+++ b/src/app/personalized-quest/intake.tsx
@@ -1,0 +1,11 @@
+import { Stack } from "expo-router";
+import { PersonalizedQuestIntake } from "../../components/personalizedQuest/PersonalizedQuestIntake";
+
+export default function PersonalizedQuestIntakeScreen() {
+  return (
+    <>
+      <Stack.Screen options={{ headerShown: false }} />
+      <PersonalizedQuestIntake />
+    </>
+  );
+}

--- a/src/components/QuestPage.tsx
+++ b/src/components/QuestPage.tsx
@@ -44,7 +44,12 @@ export const QuestPage: React.FC = () => {
     [drawHistoryQuery.data, questId]
   );
 
-  const canCompleteQuest = !!historyEntry;
+  // Personalized quests are generated for this user rather than drawn, so they
+  // have no draw-history entry but are still theirs to complete.
+  const isOwnPersonalizedQuest =
+    questQuery.data?.source === "personalized" && questQuery.data?.user_id === user?.id;
+
+  const canCompleteQuest = !!historyEntry || isOwnPersonalizedQuest;
 
   const drawDateLabel = useMemo(() => {
     if (!historyEntry) return null;
@@ -81,11 +86,15 @@ export const QuestPage: React.FC = () => {
   }
 
   const isToday = historyEntry?.draw.local_day === localDay;
-  const eyebrowText = canCompleteQuest
-    ? isToday
-      ? t("Today's quest")
-      : t("Past quest")
-    : t("Side quest");
+  const eyebrowText = isOwnPersonalizedQuest
+    ? questQuery.data?.horizon === "weekend"
+      ? t("This weekend")
+      : t("Next 24 hours")
+    : canCompleteQuest
+      ? isToday
+        ? t("Today's quest")
+        : t("Past quest")
+      : t("Side quest");
 
   return (
     <ScrollView

--- a/src/components/SideQuestPath.tsx
+++ b/src/components/SideQuestPath.tsx
@@ -27,6 +27,7 @@ import { SideQuestDailyDraw } from "./sideQuest/SideQuestDailyDraw";
 import { SideQuestQuestionnaire } from "./sideQuest/SideQuestQuestionnaire";
 import { SideQuestResults } from "./sideQuest/SideQuestResults";
 import { QuestPreviewCard } from "./ChallengePreviewCard";
+import { FeatureActionButton } from "./FeatureActionButton";
 
 function buildDraft(profile: ReturnType<typeof useSideQuests>["profile"]): SideQuestQuestionnaireDraft {
   if (!profile) return SIDE_QUEST_EMPTY_DRAFT;
@@ -332,6 +333,21 @@ export const SideQuestPath: React.FC = () => {
       />
 
       {!isRevealing && (
+        <View style={styles.personalizedWrap}>
+          <FeatureActionButton
+            title={t("Get quests made for you")}
+            subtitle={t("Answer a few questions, get two quests written for you")}
+            // INTAKE_STARTED is fired by the intake hook once the row exists,
+            // so it is deliberately not fired here as well.
+            onPress={() => router.push("/personalized-quest/intake")}
+            tone="coral"
+            variant="card"
+            fullWidth
+          />
+        </View>
+      )}
+
+      {!isRevealing && (
         <View style={styles.editPrefsWrap}>
           <Text style={styles.editPrefsPrompt}>{t("Want a different mix of side quests?")}</Text>
           <TouchableOpacity
@@ -411,6 +427,10 @@ const styles = StyleSheet.create({
   editPrefsWrap: {
     alignItems: "center",
     marginTop: "auto",
+    paddingTop: 24,
+  },
+  personalizedWrap: {
+    paddingHorizontal: 16,
     paddingTop: 24,
   },
   pageTitle: {

--- a/src/components/personalizedQuest/IntakeReadback.tsx
+++ b/src/components/personalizedQuest/IntakeReadback.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useRef } from "react";
+import { Animated, StyleSheet, View } from "react-native";
+import { colors } from "../../constants/Colors";
+import { Text } from "../StyledText";
+
+type IntakeReadbackProps = {
+  lines: string[];
+};
+
+const LINE_STAGGER_MS = 550;
+
+/**
+ * The emotional payoff of the intake, so it gets the whole screen and lands one
+ * line at a time rather than appearing as a block of summary text.
+ */
+export const IntakeReadback: React.FC<IntakeReadbackProps> = ({ lines }) => {
+  const opacities = useRef(lines.map(() => new Animated.Value(0))).current;
+  const offsets = useRef(lines.map(() => new Animated.Value(12))).current;
+
+  useEffect(() => {
+    const animations = lines.map((_, index) =>
+      Animated.parallel([
+        Animated.timing(opacities[index], {
+          toValue: 1,
+          duration: 500,
+          delay: index * LINE_STAGGER_MS,
+          useNativeDriver: true,
+        }),
+        Animated.timing(offsets[index], {
+          toValue: 0,
+          duration: 500,
+          delay: index * LINE_STAGGER_MS,
+          useNativeDriver: true,
+        }),
+      ])
+    );
+
+    Animated.stagger(0, animations).start();
+  }, [lines, opacities, offsets]);
+
+  return (
+    <View style={styles.container}>
+      {lines.map((line, index) => (
+        <Animated.View
+          key={`${index}-${line}`}
+          style={{
+            opacity: opacities[index],
+            transform: [{ translateY: offsets[index] }],
+          }}
+        >
+          <Text style={styles.line}>{line}</Text>
+        </Animated.View>
+      ))}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    gap: 28,
+    justifyContent: "center",
+    paddingVertical: 24,
+  },
+  line: {
+    color: colors.light.text,
+    fontSize: 24,
+    fontWeight: "600",
+    lineHeight: 34,
+  },
+});

--- a/src/components/personalizedQuest/IntakeTextQuestion.tsx
+++ b/src/components/personalizedQuest/IntakeTextQuestion.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+import { StyleSheet, TextInput, TouchableOpacity, View } from "react-native";
+import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
+import { colors } from "../../constants/Colors";
+import { useLanguage } from "../../contexts/LanguageContext";
+import { Text } from "../StyledText";
+
+type IntakeTextQuestionProps = {
+  question: string;
+  placeholder: string;
+  value: string;
+  onChangeText: (value: string) => void;
+  onSubmit: () => void;
+  autoFocus?: boolean;
+  /**
+   * Seam for voice input. No speech dependency exists yet; when one is added,
+   * passing this handler is all that is needed to surface the mic.
+   */
+  onVoiceInput?: () => void;
+};
+
+/**
+ * Single-line, deliberately. A textarea invites an essay, and the intake is
+ * built for speed.
+ */
+export const IntakeTextQuestion: React.FC<IntakeTextQuestionProps> = ({
+  question,
+  placeholder,
+  value,
+  onChangeText,
+  onSubmit,
+  autoFocus,
+  onVoiceInput,
+}) => {
+  const { t } = useLanguage();
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.question}>{t(question)}</Text>
+
+      <View style={styles.inputRow}>
+        <TextInput
+          style={styles.input}
+          value={value}
+          onChangeText={onChangeText}
+          placeholder={t(placeholder)}
+          placeholderTextColor={colors.light.lightText}
+          autoFocus={autoFocus}
+          multiline={false}
+          returnKeyType="next"
+          onSubmitEditing={onSubmit}
+          blurOnSubmit={false}
+          maxLength={280}
+        />
+
+        {!!onVoiceInput && (
+          <TouchableOpacity
+            onPress={onVoiceInput}
+            style={styles.micButton}
+            accessibilityLabel={t("Use voice input")}
+          >
+            <MaterialCommunityIcons name="microphone" size={22} color={colors.sideQuest.text} />
+          </TouchableOpacity>
+        )}
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 20,
+  },
+  input: {
+    borderBottomColor: colors.sideQuest.bgBorder,
+    borderBottomWidth: 2,
+    color: colors.light.text,
+    flex: 1,
+    fontSize: 18,
+    paddingBottom: 10,
+    paddingTop: 4,
+  },
+  inputRow: {
+    alignItems: "flex-end",
+    flexDirection: "row",
+    gap: 8,
+  },
+  micButton: {
+    alignItems: "center",
+    height: 40,
+    justifyContent: "center",
+    width: 40,
+  },
+  question: {
+    color: colors.light.text,
+    fontSize: 24,
+    fontWeight: "700",
+    lineHeight: 32,
+  },
+});

--- a/src/components/personalizedQuest/PersonalizedQuestIntake.tsx
+++ b/src/components/personalizedQuest/PersonalizedQuestIntake.tsx
@@ -1,0 +1,534 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { useRouter } from "expo-router";
+import { colors } from "../../constants/Colors";
+import { useLanguage } from "../../contexts/LanguageContext";
+import { usePersonalizedQuestIntake } from "../../hooks/usePersonalizedQuestIntake";
+import { captureEvent } from "../../lib/posthog";
+import { PERSONALIZED_QUEST_EVENTS } from "../../constants/analyticsEvents";
+import { GeneratedQuestSet, SoloExperience } from "../../types/personalizedQuests";
+import { FeatureActionButton } from "../FeatureActionButton";
+import { ProgressSegments } from "../ProgressSegments";
+import { QuestCard, ShareQuestExperience } from "../Quest";
+import { Text } from "../StyledText";
+import { IntakeReadback } from "./IntakeReadback";
+import { IntakeTextQuestion } from "./IntakeTextQuestion";
+
+type Step = "avoided" | "bail" | "context" | "followup" | "readback" | "quests";
+
+const SOLO_OPTIONS: { id: SoloExperience; label: string }[] = [
+  { id: "never", label: "Never" },
+  { id: "once_or_twice", label: "Once or twice" },
+  { id: "regularly", label: "Yeah, regularly" },
+];
+
+// The follow-up is conditional, so it is excluded from the progress count and
+// the bar simply holds still on that screen.
+const PROGRESS_STEPS: Step[] = ["avoided", "bail", "context", "readback", "quests"];
+
+export const PersonalizedQuestIntake: React.FC = () => {
+  const { t } = useLanguage();
+  const router = useRouter();
+  const {
+    intakeId,
+    followup,
+    questSet,
+    generating,
+    generationFailed,
+    start,
+    trackStep,
+    saveAnswer,
+    startBackgroundWork,
+    resolveFollowup,
+    finalize,
+    abandon,
+  } = usePersonalizedQuestIntake();
+
+  const [step, setStep] = useState<Step>("avoided");
+  const [avoided, setAvoided] = useState("");
+  const [bail, setBail] = useState("");
+  const [solo, setSolo] = useState<SoloExperience | null>(null);
+  const [location, setLocation] = useState("");
+  const [followupAnswer, setFollowupAnswer] = useState("");
+  const [starting, setStarting] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      try {
+        await start();
+      } finally {
+        if (!cancelled) setStarting(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [start]);
+
+  useEffect(() => {
+    trackStep(step);
+  }, [step, trackStep]);
+
+  const progressIndex = useMemo(() => {
+    const index = PROGRESS_STEPS.indexOf(step);
+    // On the follow-up, hold the bar where the context step left it.
+    return index === -1 ? PROGRESS_STEPS.indexOf("context") : index;
+  }, [step]);
+
+  const handleClose = useCallback(() => {
+    // Once the quests exist the intake is already marked completed, so closing
+    // here must not overwrite that status (or double-count in the funnel).
+    if (step !== "quests" && !questSet) abandon(step);
+    router.back();
+  }, [abandon, questSet, router, step]);
+
+  /**
+   * The read-back is the payoff screen, so an empty one is worse than none.
+   * If the model returned no lines, go straight to the quests.
+   */
+  const skipEmptyReadback = useCallback((generated: GeneratedQuestSet | null) => {
+    if (generated && generated.readback.length === 0) {
+      setStep("quests");
+    }
+  }, []);
+
+  const goToBail = useCallback(async () => {
+    if (!avoided.trim()) return;
+    await saveAnswer({ answer_avoided: avoided.trim() });
+    setStep("bail");
+  }, [avoided, saveAnswer]);
+
+  const goToContext = useCallback(async () => {
+    if (!bail.trim()) return;
+    await saveAnswer({ answer_bail: bail.trim() });
+
+    // Both background calls start here. Steps 3 and 4 are their wall time.
+    if (intakeId) startBackgroundWork(intakeId);
+
+    setStep("context");
+  }, [bail, intakeId, saveAnswer, startBackgroundWork]);
+
+  const leaveContext = useCallback(async () => {
+    if (!solo) return;
+    await saveAnswer({ answer_solo_experience: solo, location_raw: location.trim() });
+
+    const result = await resolveFollowup();
+
+    if (result.skip || !result.question) {
+      setStep("readback");
+      const generated = await finalize(null);
+      skipEmptyReadback(generated);
+      return;
+    }
+
+    setStep("followup");
+  }, [finalize, location, resolveFollowup, saveAnswer, skipEmptyReadback, solo]);
+
+  const leaveFollowup = useCallback(async () => {
+    setStep("readback");
+    const generated = await finalize(followupAnswer.trim() || null);
+    skipEmptyReadback(generated);
+  }, [finalize, followupAnswer, skipEmptyReadback]);
+
+  useEffect(() => {
+    if (step === "readback" && questSet) {
+      captureEvent(PERSONALIZED_QUEST_EVENTS.READBACK_VIEWED, {
+        line_count: questSet.readback.length,
+      });
+    }
+  }, [questSet, step]);
+
+  const goToQuests = useCallback(() => {
+    captureEvent(PERSONALIZED_QUEST_EVENTS.QUESTS_VIEWED, {
+      quest_count: questSet?.quests.length ?? 0,
+    });
+    setStep("quests");
+  }, [questSet]);
+
+  if (starting) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <View style={styles.centered}>
+          <ActivityIndicator color={colors.sideQuest.base} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  const renderStep = () => {
+    switch (step) {
+      case "avoided":
+        return (
+          <IntakeTextQuestion
+            question="What's something you've been meaning to do for months and still haven't?"
+            placeholder="that pottery class, travelling alone, asking someone out"
+            value={avoided}
+            onChangeText={setAvoided}
+            onSubmit={goToBail}
+            autoFocus
+          />
+        );
+
+      case "bail":
+        return (
+          <IntakeTextQuestion
+            question="What would make you bail on something you'd already said yes to?"
+            placeholder="going alone, having to talk in front of people, late nights"
+            value={bail}
+            onChangeText={setBail}
+            onSubmit={goToContext}
+            autoFocus
+          />
+        );
+
+      case "context":
+        return (
+          <View style={styles.contextStep}>
+            <Text style={styles.question}>{t("Ever gone to something like that on your own?")}</Text>
+
+            <View style={styles.optionsWrap}>
+              {SOLO_OPTIONS.map((option) => {
+                const active = solo === option.id;
+                return (
+                  <TouchableOpacity
+                    key={option.id}
+                    onPress={() => setSolo(option.id)}
+                    style={[styles.optionChip, active && styles.optionChipActive]}
+                  >
+                    <Text style={[styles.optionText, active && styles.optionTextActive]}>
+                      {t(option.label)}
+                    </Text>
+                  </TouchableOpacity>
+                );
+              })}
+            </View>
+
+            <View style={styles.locationBlock}>
+              <Text style={styles.locationLabel}>{t("Where are you based?")}</Text>
+              <TextInput
+                style={styles.locationInput}
+                value={location}
+                onChangeText={setLocation}
+                placeholder={t("Milano, Navigli")}
+                placeholderTextColor={colors.light.lightText}
+                multiline={false}
+                returnKeyType="done"
+                maxLength={120}
+              />
+            </View>
+          </View>
+        );
+
+      case "followup":
+        return (
+          <IntakeTextQuestion
+            question={followup.question || ""}
+            placeholder="a sentence is plenty"
+            value={followupAnswer}
+            onChangeText={setFollowupAnswer}
+            onSubmit={leaveFollowup}
+            autoFocus
+          />
+        );
+
+      case "readback":
+        if (generating || !questSet) {
+          return (
+            <View style={styles.centered}>
+              <ActivityIndicator color={colors.sideQuest.base} />
+              <Text style={styles.waitingText}>{t("Working out what's in your way...")}</Text>
+            </View>
+          );
+        }
+        return <IntakeReadback lines={questSet.readback} />;
+
+      case "quests": {
+        // The 24-hour quest is the one they act on now, so it leads; the
+        // weekend quest follows as what comes after it.
+        const todayQuest = questSet?.quests.find((quest) => quest.horizon === "today");
+        const weekendQuest = questSet?.quests.find((quest) => quest.horizon === "weekend");
+
+        return (
+          <View style={styles.questsStep}>
+            {!!todayQuest && (
+              <View style={styles.questBlock}>
+                <Text style={styles.questsHeading}>{t("Your first challenge")}</Text>
+                <Text style={styles.questsSubheading}>{t("Do this one in the next 24 hours")}</Text>
+                <QuestCard quest={todayQuest} eyebrowText={t("Next 24 hours")} />
+                <ShareQuestExperience quest={todayQuest} />
+              </View>
+            )}
+
+            {!!weekendQuest && (
+              <View style={styles.questBlockSecondary}>
+                <Text style={styles.questsThenHeading}>{t("Then, this weekend")}</Text>
+                <QuestCard quest={weekendQuest} eyebrowText={t("This weekend")} />
+                <ShareQuestExperience quest={weekendQuest} />
+              </View>
+            )}
+          </View>
+        );
+      }
+    }
+  };
+
+  const renderFooter = () => {
+    switch (step) {
+      case "avoided":
+        return (
+          <FeatureActionButton
+            title={t("Next")}
+            onPress={goToBail}
+            disabled={!avoided.trim()}
+            tone="coral"
+            variant="pill"
+            fullWidth
+          />
+        );
+
+      case "bail":
+        return (
+          <FeatureActionButton
+            title={t("Next")}
+            onPress={goToContext}
+            disabled={!bail.trim()}
+            tone="coral"
+            variant="pill"
+            fullWidth
+          />
+        );
+
+      case "context":
+        return (
+          <FeatureActionButton
+            title={t("Next")}
+            onPress={leaveContext}
+            disabled={!solo}
+            tone="coral"
+            variant="pill"
+            fullWidth
+          />
+        );
+
+      case "followup":
+        return (
+          <FeatureActionButton
+            title={followupAnswer.trim() ? t("Next") : t("Skip")}
+            onPress={leaveFollowup}
+            tone="coral"
+            variant="pill"
+            fullWidth
+          />
+        );
+
+      case "readback":
+        if (generationFailed) {
+          return (
+            <FeatureActionButton
+              title={t("Close")}
+              onPress={handleClose}
+              tone="coral"
+              variant="pill"
+              fullWidth
+            />
+          );
+        }
+        return (
+          <FeatureActionButton
+            title={t("Show me my first challenge")}
+            onPress={goToQuests}
+            disabled={generating || !questSet}
+            tone="coral"
+            variant="pill"
+            fullWidth
+          />
+        );
+
+      case "quests":
+        return (
+          <FeatureActionButton
+            title={t("Done")}
+            onPress={() => router.back()}
+            tone="coral"
+            variant="pill"
+            fullWidth
+          />
+        );
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.container} edges={["top", "bottom"]}>
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+      >
+        <View style={styles.header}>
+          <TouchableOpacity onPress={handleClose} style={styles.closeButton}>
+            <Text style={styles.closeText}>{t("Close")}</Text>
+          </TouchableOpacity>
+          <View style={styles.progressWrap}>
+            <ProgressSegments total={PROGRESS_STEPS.length} activeIndex={progressIndex} />
+          </View>
+        </View>
+
+        <ScrollView
+          style={styles.flex}
+          contentContainerStyle={styles.content}
+          keyboardShouldPersistTaps="handled"
+          keyboardDismissMode="on-drag"
+        >
+          {generationFailed && step === "readback" && (
+            <Text style={styles.errorText}>
+              {t("Something went wrong building your quests. Try again in a moment.")}
+            </Text>
+          )}
+          {renderStep()}
+        </ScrollView>
+
+        <View style={styles.footer}>{renderFooter()}</View>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  centered: {
+    alignItems: "center",
+    flex: 1,
+    gap: 12,
+    justifyContent: "center",
+  },
+  closeButton: {
+    paddingVertical: 4,
+  },
+  closeText: {
+    color: colors.light.lightText,
+    fontSize: 15,
+  },
+  container: {
+    backgroundColor: colors.light.background,
+    flex: 1,
+  },
+  content: {
+    flexGrow: 1,
+    paddingHorizontal: 20,
+    paddingTop: 24,
+  },
+  contextStep: {
+    gap: 24,
+  },
+  errorText: {
+    color: colors.sideQuest.text,
+    fontSize: 15,
+    marginBottom: 16,
+  },
+  flex: {
+    flex: 1,
+  },
+  footer: {
+    paddingBottom: 12,
+    paddingHorizontal: 20,
+    paddingTop: 8,
+  },
+  header: {
+    alignItems: "center",
+    flexDirection: "row",
+    gap: 16,
+    paddingHorizontal: 20,
+    paddingTop: 8,
+  },
+  locationBlock: {
+    gap: 10,
+  },
+  locationInput: {
+    borderBottomColor: colors.sideQuest.bgBorder,
+    borderBottomWidth: 2,
+    color: colors.light.text,
+    fontSize: 18,
+    paddingBottom: 10,
+  },
+  locationLabel: {
+    color: colors.light.text,
+    fontSize: 17,
+    fontWeight: "600",
+  },
+  optionChip: {
+    backgroundColor: colors.sideQuest.bg,
+    borderColor: colors.sideQuest.bgBorder,
+    borderRadius: 999,
+    borderWidth: 1,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+  },
+  optionChipActive: {
+    backgroundColor: colors.sideQuest.base,
+    borderColor: colors.sideQuest.text,
+  },
+  optionText: {
+    color: colors.sideQuest.textStrong,
+    fontSize: 15,
+  },
+  optionTextActive: {
+    color: colors.neutral.white,
+    fontWeight: "600",
+  },
+  optionsWrap: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
+  },
+  progressWrap: {
+    flex: 1,
+  },
+  question: {
+    color: colors.light.text,
+    fontSize: 24,
+    fontWeight: "700",
+    lineHeight: 32,
+  },
+  questBlock: {
+    gap: 12,
+  },
+  questBlockSecondary: {
+    borderTopColor: colors.sideQuest.bgBorder,
+    borderTopWidth: 1,
+    gap: 12,
+    paddingTop: 28,
+  },
+  questsHeading: {
+    color: colors.light.text,
+    fontSize: 26,
+    fontWeight: "800",
+  },
+  questsStep: {
+    gap: 28,
+  },
+  questsSubheading: {
+    color: colors.light.lightText,
+    fontSize: 15,
+    marginTop: -6,
+  },
+  questsThenHeading: {
+    color: colors.light.lightText,
+    fontSize: 17,
+    fontWeight: "700",
+  },
+  waitingText: {
+    color: colors.light.lightText,
+    fontSize: 15,
+  },
+});

--- a/src/constants/analyticsEvents.ts
+++ b/src/constants/analyticsEvents.ts
@@ -165,6 +165,26 @@ export const ESPLORA_EVENTS = {
 } as const;
 
 // ============================================
+// PERSONALIZED QUEST EVENTS
+// ============================================
+export const PERSONALIZED_QUEST_EVENTS = {
+  INTAKE_STARTED: 'pq_intake_started',
+  // Fired with a `step` property — this is what makes per-screen drop-off measurable.
+  INTAKE_STEP_VIEWED: 'pq_intake_step_viewed',
+  INTAKE_COMPLETED: 'pq_intake_completed',
+  INTAKE_ABANDONED: 'pq_intake_abandoned',
+  // Fired with `variant`: 'clarify' | 'deepen'.
+  FOLLOWUP_FIRED: 'pq_followup_fired',
+  // Fired with `reason`: 'model_skip' | 'timeout' | 'error'.
+  FOLLOWUP_SKIPPED: 'pq_followup_skipped',
+  READBACK_VIEWED: 'pq_readback_viewed',
+  QUESTS_VIEWED: 'pq_quests_viewed',
+  // Whether the speculative result was shown or a regenerated one.
+  SPECULATIVE_USED: 'pq_speculative_used',
+  GENERATION_FAILED: 'pq_generation_failed',
+} as const;
+
+// ============================================
 // USER PROPERTY KEYS (for setUserProperties)
 // ============================================
 export const USER_PROPERTIES = {
@@ -188,6 +208,7 @@ export const ANALYTICS_EVENTS = {
   CHALLENGE: CHALLENGE_EVENTS,
   PROFILE: PROFILE_EVENTS,
   SIDE_QUEST: SIDE_QUEST_EVENTS,
+  PERSONALIZED_QUEST: PERSONALIZED_QUEST_EVENTS,
   FEED: FEED_EVENTS,
   UI: UI_EVENTS,
   SCREEN: SCREEN_EVENTS,

--- a/src/constants/translations.ts
+++ b/src/constants/translations.ts
@@ -469,5 +469,36 @@ export const translations = {
   "Want a different mix of side quests?": "Vuoi un mix diverso di side quest?",
   "Edit preferences": "Modifica preferenze",
   "Back": "Indietro",
-  "Quest not found": "Quest non trovata"
+  "Quest not found": "Quest non trovata",
+
+  // Personalized side quest intake
+  "What's something you've been meaning to do for months and still haven't?":
+    "C'è qualcosa che rimandi da mesi e che ancora non hai fatto?",
+  "that pottery class, travelling alone, asking someone out":
+    "quel corso di ceramica, viaggiare da solo, invitare qualcuno fuori",
+  "What would make you bail on something you'd already said yes to?":
+    "Cosa ti farebbe dare buca a qualcosa a cui avevi già detto di sì?",
+  "going alone, having to talk in front of people, late nights":
+    "andarci da solo, dover parlare davanti agli altri, fare tardi",
+  "Ever gone to something like that on your own?": "Ci sei mai andato da solo a una cosa del genere?",
+  "Never": "Mai",
+  "Once or twice": "Una o due volte",
+  "Yeah, regularly": "Sì, regolarmente",
+  "Where are you based?": "Dove vivi?",
+  "Milano, Navigli": "Milano, Navigli",
+  "a sentence is plenty": "basta una frase",
+  "Working out what's in your way...": "Sto capendo cosa ti blocca...",
+  "Your first challenge": "La tua prima sfida",
+  "Do this one in the next 24 hours": "Falla nelle prossime 24 ore",
+  "Then, this weekend": "Poi, questo weekend",
+  "Next 24 hours": "Prossime 24 ore",
+  "This weekend": "Questo weekend",
+  "Show me my first challenge": "Mostrami la mia prima sfida",
+  "Something went wrong building your quests. Try again in a moment.":
+    "Qualcosa è andato storto nel creare le tue quest. Riprova tra poco.",
+  "Get quests made for you": "Ottieni quest fatte per te",
+  "Answer a few questions, get two quests written for you":
+    "Rispondi a poche domande, ricevi due quest scritte per te",
+  "Use voice input": "Usa l'input vocale",
+  "Close": "Chiudi"
 };

--- a/src/hooks/usePersonalizedQuestIntake.ts
+++ b/src/hooks/usePersonalizedQuestIntake.ts
@@ -1,0 +1,269 @@
+import { useCallback, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "../contexts/AuthContext";
+import { useLanguage } from "../contexts/LanguageContext";
+import { captureEvent } from "../lib/posthog";
+import { PERSONALIZED_QUEST_EVENTS } from "../constants/analyticsEvents";
+import { personalizedQuestService, llmQuestSource } from "../services/personalizedQuestService";
+import {
+  GeneratedQuestSet,
+  IntakeAnswers,
+  QuestFollowup,
+  SoloExperience,
+} from "../types/personalizedQuests";
+
+/**
+ * How long the flow will wait for the follow-up question once the user has
+ * finished the tap/location screen. The follow-up is a bonus, never a gate.
+ */
+const FOLLOWUP_WAIT_MS = 2500;
+
+const NO_FOLLOWUP: QuestFollowup = { skip: true, question: null, variant: null };
+
+/** Distinguishes "the call was too slow" from "the model chose to skip". */
+const TIMED_OUT = Symbol("followup_timed_out");
+
+function withTimeout<T>(promise: Promise<T>, ms: number, fallback: T): Promise<T> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      resolve(fallback);
+    }, ms);
+
+    promise
+      .then((value) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(value);
+      })
+      .catch(() => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(fallback);
+      });
+  });
+}
+
+export function usePersonalizedQuestIntake() {
+  const { user } = useAuth();
+  const { language } = useLanguage();
+  const queryClient = useQueryClient();
+
+  const [intakeId, setIntakeId] = useState<number | null>(null);
+  const [followup, setFollowup] = useState<QuestFollowup>(NO_FOLLOWUP);
+  const [questSet, setQuestSet] = useState<GeneratedQuestSet | null>(null);
+  const [generating, setGenerating] = useState(false);
+  const [generationFailed, setGenerationFailed] = useState(false);
+
+  // Background work started on Q2 submit. Held in refs so re-renders during
+  // steps 3 and 4 never restart it.
+  const followupPromiseRef = useRef<Promise<QuestFollowup> | null>(null);
+  const speculativePromiseRef = useRef<Promise<GeneratedQuestSet> | null>(null);
+  const answersRef = useRef<IntakeAnswers>({
+    answer_avoided: "",
+    answer_bail: "",
+    answer_solo_experience: null,
+    location_raw: "",
+  });
+
+  const start = useCallback(async () => {
+    if (!user?.id) return null;
+
+    const intake = await personalizedQuestService.createIntake(user.id);
+    setIntakeId(intake.id);
+    captureEvent(PERSONALIZED_QUEST_EVENTS.INTAKE_STARTED, { intake_id: intake.id });
+    return intake.id;
+  }, [user?.id]);
+
+  const trackStep = useCallback((step: string) => {
+    captureEvent(PERSONALIZED_QUEST_EVENTS.INTAKE_STEP_VIEWED, { step });
+  }, []);
+
+  const saveAnswer = useCallback(
+    async (patch: Partial<IntakeAnswers>) => {
+      answersRef.current = { ...answersRef.current, ...patch };
+      if (!intakeId) return;
+
+      try {
+        await personalizedQuestService.saveAnswers(intakeId, {
+          ...(patch.answer_avoided !== undefined && { answer_avoided: patch.answer_avoided }),
+          ...(patch.answer_bail !== undefined && { answer_bail: patch.answer_bail }),
+          ...(patch.answer_solo_experience !== undefined && {
+            answer_solo_experience: patch.answer_solo_experience as SoloExperience | null,
+          }),
+          ...(patch.location_raw !== undefined && { location_raw: patch.location_raw }),
+        });
+      } catch (error) {
+        // A failed autosave must not interrupt the flow.
+        console.warn("personalized quest autosave failed:", error);
+      }
+    },
+    [intakeId]
+  );
+
+  /**
+   * Fired on Q2 submit. Kicks off the follow-up question and a speculative
+   * generation from what we have so far, in parallel. Steps 3 and 4 give both
+   * calls wall time.
+   */
+  const startBackgroundWork = useCallback(
+    (id: number) => {
+      if (followupPromiseRef.current || speculativePromiseRef.current) return;
+
+      const answers = answersRef.current;
+
+      followupPromiseRef.current = personalizedQuestService.generateFollowup({
+        answerAvoided: answers.answer_avoided,
+        answerBail: answers.answer_bail,
+        locale: language,
+      });
+
+      const speculative = llmQuestSource.generate({ intakeId: id, answers, locale: language });
+
+      // Nothing awaits this until the read-back step, so a failure in the
+      // meantime would surface as an unhandled rejection. This no-op handler
+      // silences that; the stored promise still rejects when awaited later.
+      speculative.catch(() => undefined);
+
+      speculativePromiseRef.current = speculative;
+    },
+    [language]
+  );
+
+  /**
+   * Called when the tap/location screen is done. Races the follow-up against a
+   * short timeout so the flow never stalls on it.
+   */
+  const resolveFollowup = useCallback(async (): Promise<QuestFollowup> => {
+    if (!followupPromiseRef.current) {
+      setFollowup(NO_FOLLOWUP);
+      return NO_FOLLOWUP;
+    }
+
+    const result = await withTimeout<QuestFollowup | typeof TIMED_OUT>(
+      followupPromiseRef.current,
+      FOLLOWUP_WAIT_MS,
+      TIMED_OUT
+    );
+
+    if (result === TIMED_OUT || result.skip || !result.question || !result.variant) {
+      captureEvent(PERSONALIZED_QUEST_EVENTS.FOLLOWUP_SKIPPED, {
+        reason: result === TIMED_OUT ? "timeout" : result.error ? "error" : "model_skip",
+      });
+      setFollowup(NO_FOLLOWUP);
+      return NO_FOLLOWUP;
+    }
+
+    captureEvent(PERSONALIZED_QUEST_EVENTS.FOLLOWUP_FIRED, { variant: result.variant });
+    setFollowup(result);
+
+    if (intakeId) {
+      personalizedQuestService
+        .saveAnswers(intakeId, {
+          followup_question: result.question,
+          followup_variant: result.variant,
+        })
+        .catch(() => undefined);
+    }
+
+    return result;
+  }, [intakeId]);
+
+  /**
+   * Produces the read-back and quests. If the follow-up was answered we
+   * regenerate with it and discard the speculative result; otherwise the
+   * speculative result is used so the screen appears with no wait.
+   */
+  const finalize = useCallback(
+    async (followupAnswer: string | null) => {
+      if (!intakeId) return null;
+
+      setGenerating(true);
+      setGenerationFailed(false);
+
+      const usedSpeculative = !followupAnswer?.trim();
+
+      try {
+        let result: GeneratedQuestSet;
+
+        if (usedSpeculative) {
+          result = speculativePromiseRef.current
+            ? await speculativePromiseRef.current
+            : await llmQuestSource.generate({
+                intakeId,
+                answers: answersRef.current,
+                locale: language,
+              });
+        } else {
+          answersRef.current = {
+            ...answersRef.current,
+            followup_question: followup.question,
+            followup_answer: followupAnswer,
+          };
+
+          await personalizedQuestService
+            .saveAnswers(intakeId, { followup_answer: followupAnswer })
+            .catch(() => undefined);
+
+          result = await llmQuestSource.generate({
+            intakeId,
+            answers: answersRef.current,
+            locale: language,
+          });
+        }
+
+        captureEvent(PERSONALIZED_QUEST_EVENTS.SPECULATIVE_USED, {
+          used_speculative: usedSpeculative,
+        });
+
+        setQuestSet(result);
+        await personalizedQuestService.completeIntake(intakeId);
+        captureEvent(PERSONALIZED_QUEST_EVENTS.INTAKE_COMPLETED, { intake_id: intakeId });
+
+        // The new quests are the user's own, so any cached quest list is stale.
+        queryClient.invalidateQueries({ queryKey: ["side-quests"] });
+
+        return result;
+      } catch (error) {
+        console.error("personalized quest generation failed:", error);
+        captureEvent(PERSONALIZED_QUEST_EVENTS.GENERATION_FAILED, {
+          used_speculative: usedSpeculative,
+        });
+        setGenerationFailed(true);
+        return null;
+      } finally {
+        setGenerating(false);
+      }
+    },
+    [followup.question, intakeId, language, queryClient]
+  );
+
+  const abandon = useCallback(
+    (step: string) => {
+      captureEvent(PERSONALIZED_QUEST_EVENTS.INTAKE_ABANDONED, { step, intake_id: intakeId });
+      if (!intakeId) return;
+      personalizedQuestService.saveAnswers(intakeId, { status: "abandoned" }).catch(() => undefined);
+    },
+    [intakeId]
+  );
+
+  return {
+    intakeId,
+    followup,
+    questSet,
+    generating,
+    generationFailed,
+    answers: answersRef.current,
+    start,
+    trackStep,
+    saveAnswer,
+    startBackgroundWork,
+    resolveFollowup,
+    finalize,
+    abandon,
+  };
+}

--- a/src/services/personalizedQuestService.ts
+++ b/src/services/personalizedQuestService.ts
@@ -1,0 +1,150 @@
+import { supabase } from "../lib/supabase";
+import {
+  GeneratedQuestSet,
+  IntakeAnswers,
+  IntakeStatus,
+  PersonalizedQuest,
+  PersonalizedQuestIntake,
+  QuestFollowup,
+  QuestSource,
+  SoloExperience,
+} from "../types/personalizedQuests";
+
+const INTAKE_TABLE = "personalized_quest_intakes";
+
+export const personalizedQuestService = {
+  async createIntake(userId: string): Promise<PersonalizedQuestIntake> {
+    const { data, error } = await supabase
+      .from(INTAKE_TABLE)
+      .insert({ user_id: userId, status: "in_progress" })
+      .select("*")
+      .single();
+
+    if (error) throw error;
+    return data as PersonalizedQuestIntake;
+  },
+
+  /**
+   * Patches whatever the user has answered so far. Called after each step so a
+   * drop-off still leaves their words behind.
+   */
+  async saveAnswers(
+    intakeId: number,
+    patch: Partial<{
+      answer_avoided: string;
+      answer_bail: string;
+      answer_solo_experience: SoloExperience | null;
+      location_raw: string;
+      followup_question: string | null;
+      followup_variant: string | null;
+      followup_answer: string | null;
+      status: IntakeStatus;
+      completed_at: string | null;
+    }>
+  ): Promise<void> {
+    const { error } = await supabase
+      .from(INTAKE_TABLE)
+      .update({ ...patch, updated_at: new Date().toISOString() })
+      .eq("id", intakeId);
+
+    if (error) throw error;
+  },
+
+  async completeIntake(intakeId: number): Promise<void> {
+    await this.saveAnswers(intakeId, {
+      status: "completed",
+      completed_at: new Date().toISOString(),
+    });
+  },
+
+  async fetchLatestIntake(userId: string): Promise<PersonalizedQuestIntake | null> {
+    const { data, error } = await supabase
+      .from(INTAKE_TABLE)
+      .select("*")
+      .eq("user_id", userId)
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (error) throw error;
+    return (data as PersonalizedQuestIntake) || null;
+  },
+
+  async fetchQuestsForIntake(intakeId: number): Promise<PersonalizedQuest[]> {
+    const { data, error } = await supabase
+      .from("side_quests")
+      .select("*")
+      .eq("intake_id", intakeId)
+      .order("horizon", { ascending: true });
+
+    if (error) throw error;
+    return (data || []) as PersonalizedQuest[];
+  },
+
+  /**
+   * Fires the follow-up generation. Resolves to a skip rather than rejecting:
+   * the intake must never block or fail on this call.
+   */
+  async generateFollowup(params: {
+    answerAvoided: string;
+    answerBail: string;
+    locale: string;
+  }): Promise<QuestFollowup> {
+    const skipped: QuestFollowup = { skip: true, question: null, variant: null };
+    const failed: QuestFollowup = { ...skipped, error: true };
+
+    try {
+      const { data, error } = await supabase.functions.invoke("generate-quest-followup", {
+        body: {
+          answer_avoided: params.answerAvoided,
+          answer_bail: params.answerBail,
+          locale: params.locale,
+        },
+      });
+
+      if (error || !data) return failed;
+
+      const followup = data as QuestFollowup;
+      if (followup.skip || !followup.question || !followup.variant) return skipped;
+
+      return followup;
+    } catch {
+      return failed;
+    }
+  },
+
+  async generateQuests(params: {
+    intakeId: number;
+    answers: IntakeAnswers;
+    locale: string;
+  }): Promise<GeneratedQuestSet> {
+    const { data, error } = await supabase.functions.invoke("generate-personalized-quests", {
+      body: {
+        intake_id: params.intakeId,
+        answer_avoided: params.answers.answer_avoided,
+        answer_bail: params.answers.answer_bail,
+        answer_solo_experience: params.answers.answer_solo_experience,
+        location_raw: params.answers.location_raw,
+        followup_question: params.answers.followup_question ?? null,
+        followup_answer: params.answers.followup_answer ?? null,
+        locale: params.locale,
+      },
+    });
+
+    if (error) throw error;
+    if (!data || (data as { error?: string }).error) {
+      throw new Error((data as { error?: string })?.error || "generation_failed");
+    }
+
+    return data as GeneratedQuestSet;
+  },
+};
+
+/**
+ * Current quest source. An events-backed source can be added alongside this one
+ * and selected without the intake UI changing.
+ */
+export const llmQuestSource: QuestSource = {
+  id: "llm",
+  generate: (params) => personalizedQuestService.generateQuests(params),
+};

--- a/src/services/sideQuestService.ts
+++ b/src/services/sideQuestService.ts
@@ -271,6 +271,9 @@ export const sideQuestService = {
     const { data, error } = await supabase
       .from("side_quests")
       .select("*")
+      // Personalized quests are generated for one user and must never enter
+      // the curated draw pool.
+      .is("user_id", null)
       .eq("is_active", true)
       .order("id", { ascending: true });
 

--- a/src/types/personalizedQuests.ts
+++ b/src/types/personalizedQuests.ts
@@ -1,0 +1,80 @@
+import { SideQuest } from "./sideQuests";
+
+export type SoloExperience = "never" | "once_or_twice" | "regularly";
+
+export type FollowupVariant = "clarify" | "deepen";
+
+export type IntakeStatus = "in_progress" | "completed" | "abandoned";
+
+export type LocationSource = "manual" | "gps" | "places";
+
+export type QuestHorizon = "today" | "weekend";
+
+/**
+ * Raw answers are persisted verbatim: future personalization depends on the
+ * user's actual wording, not on derived tags.
+ */
+export interface PersonalizedQuestIntake {
+  id: number;
+  user_id: string;
+  answer_avoided: string | null;
+  answer_bail: string | null;
+  answer_solo_experience: SoloExperience | null;
+  location_raw: string | null;
+  location_city: string | null;
+  location_lat: number | null;
+  location_lng: number | null;
+  location_source: LocationSource | null;
+  followup_question: string | null;
+  followup_variant: FollowupVariant | null;
+  followup_answer: string | null;
+  readback_lines: string[];
+  status: IntakeStatus;
+  completed_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+/** A generated quest is an ordinary side quest scoped to one user. */
+export interface PersonalizedQuest extends SideQuest {
+  user_id: string;
+  source: "personalized";
+  intake_id: number | null;
+  horizon: QuestHorizon;
+}
+
+export interface QuestFollowup {
+  skip: boolean;
+  question: string | null;
+  variant: FollowupVariant | null;
+  /** Set when the call failed, so a skip can be reported as an error not a model choice. */
+  error?: boolean;
+}
+
+export interface GeneratedQuestSet {
+  readback: string[];
+  quests: PersonalizedQuest[];
+}
+
+/** The answers gathered so far, sent to generation. */
+export interface IntakeAnswers {
+  answer_avoided: string;
+  answer_bail: string;
+  answer_solo_experience: SoloExperience | null;
+  location_raw: string;
+  followup_question?: string | null;
+  followup_answer?: string | null;
+}
+
+/**
+ * Seam for the events pipeline. Quests come from an LLM today; a real events
+ * source drops in later as a second implementation without touching the UI.
+ */
+export interface QuestSource {
+  readonly id: string;
+  generate(params: {
+    intakeId: number;
+    answers: IntakeAnswers;
+    locale: string;
+  }): Promise<GeneratedQuestSet>;
+}

--- a/src/types/sideQuests.ts
+++ b/src/types/sideQuests.ts
@@ -85,6 +85,12 @@ export interface SideQuest {
   is_active: boolean;
   created_at: string;
   updated_at: string;
+  // Personalized quests are ordinary side quests scoped to one user.
+  // Curated quests leave user_id null.
+  user_id?: string | null;
+  source?: "curated" | "personalized";
+  intake_id?: number | null;
+  horizon?: "today" | "weekend" | null;
 }
 
 export interface SideQuestDraw {

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -357,8 +357,20 @@ inspector_port = 8083
 # The Deno major version to use.
 deno_version = 2
 
-# [edge_runtime.secrets]
-# secret_key = "env(SECRET_VALUE)"
+# Read from the gitignored .env at the project root, so the key never lands in git.
+[edge_runtime.secrets]
+OPENAI_API_KEY = "env(OPENAI_API_KEY)"
+
+# These two authenticate the caller in-function via auth.getUser(), which
+# validates the token against the auth server and returns 401 when it fails.
+# The gateway's own check is disabled because it verifies with the legacy HS256
+# JWT secret while the auth server now issues ES256 tokens, so it rejects every
+# valid token locally.
+[functions.generate-quest-followup]
+verify_jwt = false
+
+[functions.generate-personalized-quests]
+verify_jwt = false
 
 [analytics]
 enabled = true

--- a/supabase/functions/_shared/personalizedQuest.ts
+++ b/supabase/functions/_shared/personalizedQuest.ts
@@ -1,0 +1,244 @@
+// Shared vocabulary and sanitisation for LLM-generated side quests.
+//
+// side_quests carries NOT NULL tag columns with cardinality CHECK constraints.
+// OpenAI strict json_schema mode does not support minItems/maxItems, so the
+// model is constrained to the right *values* by enum and the *cardinality* is
+// clamped here. Anything missing falls back to a default, so a malformed model
+// response can never fail the insert.
+
+export const GOAL_TAGS = [
+  'novelty',
+  'fun',
+  'connection',
+  'momentum',
+  'creativity',
+  'better_stories',
+] as const;
+
+export const BARRIER_TAGS = [
+  'low_energy',
+  'overthinking',
+  'spending_money',
+  'planning',
+  'social_hesitation',
+  'going_far',
+  'not_knowing',
+  'feeling_self_conscious',
+] as const;
+
+export const CONTEXT_TAGS = [
+  'at_home',
+  'near_home',
+  'out_in_the_city',
+  'with_other_people',
+  'solo',
+] as const;
+
+export const TYPE_TAGS = [
+  'playful',
+  'creative',
+  'exploratory',
+  'social',
+  'reflective',
+  'growth_edge',
+] as const;
+
+export const OUTCOME_TAGS = [
+  'did_something_unusual',
+  'more_stories',
+  'days_less_repetitive',
+  'followed_impulses',
+  'explored_more',
+  'felt_more_alive',
+  'shared_more_with_people',
+] as const;
+
+export const AVOID_FLAGS = [
+  'spending_money',
+  'talking_to_strangers',
+  'group_social_situations',
+  'lots_of_planning',
+  'physically_demanding',
+  'nighttime',
+  'going_far',
+] as const;
+
+export const STRETCH_LEVELS = ['easy_win', 'moderate_push', 'bold_nudge'] as const;
+
+export type Horizon = 'today' | 'weekend';
+
+export type GeneratedQuest = {
+  horizon: Horizon;
+  title: string;
+  summary: string;
+  goal_tags: string[];
+  barrier_tags: string[];
+  context_tags: string[];
+  type_tags: string[];
+  outcome_tags: string[];
+  avoid_flags: string[];
+  stretch_level: string;
+  cost_level: number;
+  planning_level: number;
+  social_level: number;
+  physical_level: number;
+  distance_level: number;
+  night_level: number;
+};
+
+function tagArraySchema(values: readonly string[]) {
+  return {
+    type: 'array',
+    items: { type: 'string', enum: [...values] },
+  };
+}
+
+function levelSchema() {
+  return { type: 'integer', minimum: 0, maximum: 3 };
+}
+
+export const QUEST_GENERATION_SCHEMA = {
+  type: 'object',
+  properties: {
+    readback: {
+      type: 'array',
+      description: 'Exactly three short lines.',
+      items: { type: 'string', maxLength: 90 },
+    },
+    quests: {
+      type: 'array',
+      description: 'Exactly two quests: one with horizon "today", one with horizon "weekend".',
+      items: {
+        type: 'object',
+        properties: {
+          horizon: { type: 'string', enum: ['today', 'weekend'] },
+          title: { type: 'string', maxLength: 60 },
+          summary: { type: 'string', maxLength: 160 },
+          goal_tags: tagArraySchema(GOAL_TAGS),
+          barrier_tags: tagArraySchema(BARRIER_TAGS),
+          context_tags: tagArraySchema(CONTEXT_TAGS),
+          type_tags: tagArraySchema(TYPE_TAGS),
+          outcome_tags: tagArraySchema(OUTCOME_TAGS),
+          avoid_flags: tagArraySchema(AVOID_FLAGS),
+          stretch_level: { type: 'string', enum: [...STRETCH_LEVELS] },
+          cost_level: levelSchema(),
+          planning_level: levelSchema(),
+          social_level: levelSchema(),
+          physical_level: levelSchema(),
+          distance_level: levelSchema(),
+          night_level: { type: 'integer', minimum: 0, maximum: 1 },
+        },
+        required: [
+          'horizon',
+          'title',
+          'summary',
+          'goal_tags',
+          'barrier_tags',
+          'context_tags',
+          'type_tags',
+          'outcome_tags',
+          'avoid_flags',
+          'stretch_level',
+          'cost_level',
+          'planning_level',
+          'social_level',
+          'physical_level',
+          'distance_level',
+          'night_level',
+        ],
+        additionalProperties: false,
+      },
+    },
+  },
+  required: ['readback', 'quests'],
+  additionalProperties: false,
+} as const;
+
+function clampTags(
+  raw: unknown,
+  allowed: readonly string[],
+  min: number,
+  max: number,
+  fallback: string,
+): string[] {
+  const list = Array.isArray(raw) ? raw : [];
+  const seen = new Set<string>();
+  for (const item of list) {
+    if (typeof item === 'string' && allowed.includes(item)) {
+      seen.add(item);
+    }
+  }
+  const cleaned = [...seen].slice(0, max);
+  while (cleaned.length < min) {
+    if (!cleaned.includes(fallback)) {
+      cleaned.push(fallback);
+    } else {
+      const filler = allowed.find((value) => !cleaned.includes(value));
+      if (!filler) break;
+      cleaned.push(filler);
+    }
+  }
+  return cleaned;
+}
+
+function clampLevel(raw: unknown, max: number, fallback: number): number {
+  const value = typeof raw === 'number' && Number.isFinite(raw) ? Math.round(raw) : fallback;
+  return Math.min(Math.max(value, 0), max);
+}
+
+function clampText(raw: unknown, max: number, fallback: string): string {
+  const value = typeof raw === 'string' ? raw.trim() : '';
+  if (!value) return fallback;
+  return value.length > max ? value.slice(0, max).trimEnd() : value;
+}
+
+export function sanitizeQuest(raw: Record<string, unknown>, horizon: Horizon): GeneratedQuest {
+  return {
+    horizon,
+    title: clampText(raw.title, 60, horizon === 'today' ? 'Something small today' : 'The real one this weekend'),
+    summary: clampText(raw.summary, 160, 'A concrete step toward the thing you have been putting off.'),
+    goal_tags: clampTags(raw.goal_tags, GOAL_TAGS, 1, 3, 'momentum'),
+    barrier_tags: clampTags(raw.barrier_tags, BARRIER_TAGS, 1, 2, 'overthinking'),
+    context_tags: clampTags(raw.context_tags, CONTEXT_TAGS, 1, 4, 'near_home'),
+    type_tags: clampTags(raw.type_tags, TYPE_TAGS, 1, 3, 'growth_edge'),
+    outcome_tags: clampTags(raw.outcome_tags, OUTCOME_TAGS, 1, 3, 'did_something_unusual'),
+    // avoid_flags has no minimum, so an empty array is valid.
+    avoid_flags: clampTags(raw.avoid_flags, AVOID_FLAGS, 0, AVOID_FLAGS.length, ''),
+    stretch_level: STRETCH_LEVELS.includes(raw.stretch_level as typeof STRETCH_LEVELS[number])
+      ? (raw.stretch_level as string)
+      : horizon === 'today'
+        ? 'easy_win'
+        : 'moderate_push',
+    cost_level: clampLevel(raw.cost_level, 3, 0),
+    planning_level: clampLevel(raw.planning_level, 3, horizon === 'today' ? 0 : 1),
+    social_level: clampLevel(raw.social_level, 3, 1),
+    physical_level: clampLevel(raw.physical_level, 3, 0),
+    distance_level: clampLevel(raw.distance_level, 3, horizon === 'today' ? 0 : 1),
+    night_level: clampLevel(raw.night_level, 1, 0),
+  };
+}
+
+/**
+ * Always returns exactly two quests, one per horizon, even if the model
+ * returned duplicates, one, or none.
+ */
+export function sanitizeQuestPair(raw: unknown): GeneratedQuest[] {
+  const list = Array.isArray(raw) ? (raw as Record<string, unknown>[]) : [];
+  const horizons: Horizon[] = ['today', 'weekend'];
+
+  return horizons.map((horizon, index) => {
+    const match = list.find((item) => item?.horizon === horizon) ?? list[index] ?? {};
+    return sanitizeQuest(match, horizon);
+  });
+}
+
+export function sanitizeReadback(raw: unknown): string[] {
+  const list = Array.isArray(raw) ? raw : [];
+  const lines = list
+    .filter((line): line is string => typeof line === 'string')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .slice(0, 3);
+
+  return lines;
+}

--- a/supabase/functions/generate-personalized-quests/index.ts
+++ b/supabase/functions/generate-personalized-quests/index.ts
@@ -1,0 +1,198 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.49.1';
+// npm: specifier rather than the esm.sh URL used elsewhere in this folder:
+// esm.sh serves an X-TypeScript-Types header pointing at an undici-types .d.ts
+// the edge runtime cannot resolve, which fails the worker at boot.
+import OpenAI from 'npm:openai@6.27.0';
+import { corsHeaders } from '../_shared/cors.ts';
+import { getPromptContent, applyTemplate } from '../_shared/prompts.ts';
+import {
+  QUEST_GENERATION_SCHEMA,
+  sanitizeQuestPair,
+  sanitizeReadback,
+} from '../_shared/personalizedQuest.ts';
+
+// Produces the read-back lines and the two quests, and writes the quests into
+// side_quests scoped to the caller.
+//
+// Called twice per intake: speculatively right after Q2, then again with the
+// follow-up answer if one came back. The second call replaces the first call's
+// quests for the same intake — they are not referenced by anything yet.
+
+type Body = {
+  intake_id?: number;
+  answer_avoided?: string;
+  answer_bail?: string;
+  answer_solo_experience?: string;
+  location_raw?: string;
+  followup_question?: string;
+  followup_answer?: string;
+  locale?: string;
+};
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL');
+  const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+  const openaiApiKey = Deno.env.get('OPENAI_API_KEY');
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    return json({ error: 'missing supabase env' }, 500);
+  }
+  if (!openaiApiKey) {
+    return json({ error: 'missing openai env' }, 500);
+  }
+
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader) {
+    return json({ error: 'missing authorization' }, 401);
+  }
+
+  // Service role is required to read `prompts` (RLS on, no select policy).
+  const admin = createClient(supabaseUrl, serviceRoleKey);
+
+  const { data: userData } = await admin.auth.getUser(authHeader.replace('Bearer ', ''));
+  const user = userData?.user;
+  if (!user) {
+    return json({ error: 'invalid authorization' }, 401);
+  }
+
+  try {
+    const body = (await req.json()) as Body;
+    const intakeId = body.intake_id;
+
+    if (!intakeId) {
+      return json({ error: 'intake_id is required' }, 400);
+    }
+
+    // Service role bypasses RLS, so ownership is checked explicitly.
+    const { data: intake, error: intakeError } = await admin
+      .from('personalized_quest_intakes')
+      .select('id, user_id')
+      .eq('id', intakeId)
+      .maybeSingle();
+
+    if (intakeError) {
+      throw new Error(`intake fetch error: ${intakeError.message}`);
+    }
+    if (!intake || intake.user_id !== user.id) {
+      return json({ error: 'intake not found' }, 404);
+    }
+
+    const locale = body.locale === 'en' ? 'en' : 'it';
+    const none = locale === 'en' ? 'not given' : 'non indicato';
+
+    const vars = {
+      answer_avoided: (body.answer_avoided || '').trim() || none,
+      answer_bail: (body.answer_bail || '').trim() || none,
+      answer_solo_experience: (body.answer_solo_experience || '').trim() || none,
+      location_raw: (body.location_raw || '').trim() || none,
+      followup_question: (body.followup_question || '').trim() || none,
+      followup_answer: (body.followup_answer || '').trim() || none,
+    };
+
+    const [readbackTemplate, generationTemplate] = await Promise.all([
+      getPromptContent(admin, 'personalized_quest_readback', locale),
+      getPromptContent(admin, 'personalized_quest_generation', locale),
+    ]);
+
+    if (!readbackTemplate || !generationTemplate) {
+      return json({ error: 'missing_prompt_template' }, 500);
+    }
+
+    const prompt = [
+      applyTemplate(readbackTemplate, vars),
+      '---',
+      applyTemplate(generationTemplate, vars),
+    ].join('\n\n');
+
+    const openai = new OpenAI({ apiKey: openaiApiKey });
+    const res = await openai.responses.create({
+      model: 'gpt-4.1-mini',
+      temperature: 0.9,
+      input: [
+        {
+          role: 'system',
+          content:
+            'You design concrete personal challenges and write blunt, specific read-backs. Never mention AI or being a model. No therapy-speak, no validation, no generic motivation.',
+        },
+        { role: 'user', content: prompt },
+      ],
+      text: {
+        format: {
+          type: 'json_schema',
+          name: 'personalized_quests',
+          strict: true,
+          schema: QUEST_GENERATION_SCHEMA,
+        },
+      },
+    });
+
+    const text = res.output_text;
+    if (!text) {
+      return json({ error: 'empty_model_response' }, 502);
+    }
+
+    let parsed: { readback?: unknown; quests?: unknown };
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      return json({ error: 'unparseable_model_response' }, 502);
+    }
+
+    const readback = sanitizeReadback(parsed.readback);
+    const quests = sanitizeQuestPair(parsed.quests);
+
+    // Replace any quests from an earlier (speculative) run for this intake.
+    // Nothing references them yet, so this is safe.
+    const { error: deleteError } = await admin
+      .from('side_quests')
+      .delete()
+      .eq('intake_id', intakeId)
+      .eq('user_id', user.id);
+
+    if (deleteError) {
+      throw new Error(`quest cleanup error: ${deleteError.message}`);
+    }
+
+    const { data: inserted, error: insertError } = await admin
+      .from('side_quests')
+      .insert(
+        quests.map((quest) => ({
+          ...quest,
+          user_id: user.id,
+          source: 'personalized',
+          intake_id: intakeId,
+          is_active: true,
+        })),
+      )
+      .select('*');
+
+    if (insertError) {
+      throw new Error(`quest insert error: ${insertError.message}`);
+    }
+
+    const { error: updateError } = await admin
+      .from('personalized_quest_intakes')
+      .update({ readback_lines: readback, updated_at: new Date().toISOString() })
+      .eq('id', intakeId);
+
+    if (updateError) {
+      throw new Error(`intake update error: ${updateError.message}`);
+    }
+
+    return json({ readback, quests: inserted || [] });
+  } catch (error) {
+    console.error('generate-personalized-quests error:', error);
+    return json({ error: 'generation_failed' }, 500);
+  }
+});

--- a/supabase/functions/generate-quest-followup/index.ts
+++ b/supabase/functions/generate-quest-followup/index.ts
@@ -1,0 +1,145 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.49.1';
+// npm: specifier rather than the esm.sh URL used elsewhere in this folder:
+// esm.sh serves an X-TypeScript-Types header pointing at an undici-types .d.ts
+// the edge runtime cannot resolve, which fails the worker at boot.
+import OpenAI from 'npm:openai@6.27.0';
+import { corsHeaders } from '../_shared/cors.ts';
+import { getPromptContent, applyTemplate } from '../_shared/prompts.ts';
+
+// Generates the single follow-up question shown mid-intake. The client fires
+// this speculatively and never blocks on it: if it is slow, errors, or the
+// model decides the question would not change anything, the flow skips it.
+
+type Body = {
+  answer_avoided?: string;
+  answer_bail?: string;
+  locale?: string;
+};
+
+type Followup = {
+  skip: boolean;
+  question: string | null;
+  variant: 'clarify' | 'deepen' | null;
+};
+
+const FOLLOWUP_SCHEMA = {
+  type: 'object',
+  properties: {
+    skip: {
+      type: 'boolean',
+      description: 'True when the question would not change the quest, its difficulty, or the read-back.',
+    },
+    question: { type: ['string', 'null'], maxLength: 100 },
+    variant: { type: ['string', 'null'], enum: ['clarify', 'deepen', null] },
+  },
+  required: ['skip', 'question', 'variant'],
+  additionalProperties: false,
+} as const;
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}
+
+const SKIPPED: Followup = { skip: true, question: null, variant: null };
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL');
+  const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+  const openaiApiKey = Deno.env.get('OPENAI_API_KEY');
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    return json({ error: 'missing supabase env' }, 500);
+  }
+  if (!openaiApiKey) {
+    return json({ error: 'missing openai env' }, 500);
+  }
+
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader) {
+    return json({ error: 'missing authorization' }, 401);
+  }
+
+  // Service role is required to read `prompts` (RLS on, no select policy).
+  const admin = createClient(supabaseUrl, serviceRoleKey);
+
+  const { data: userData } = await admin.auth.getUser(authHeader.replace('Bearer ', ''));
+  if (!userData?.user) {
+    return json({ error: 'invalid authorization' }, 401);
+  }
+
+  try {
+    const body = (await req.json()) as Body;
+    const answerAvoided = (body.answer_avoided || '').trim();
+    const answerBail = (body.answer_bail || '').trim();
+
+    // Nothing to build a follow-up from.
+    if (!answerAvoided && !answerBail) {
+      return json(SKIPPED);
+    }
+
+    const locale = body.locale === 'en' ? 'en' : 'it';
+    const template = await getPromptContent(admin, 'personalized_quest_followup', locale);
+
+    if (!template) {
+      return json(SKIPPED);
+    }
+
+    const prompt = applyTemplate(template, {
+      answer_avoided: answerAvoided,
+      answer_bail: answerBail,
+    });
+
+    const openai = new OpenAI({ apiKey: openaiApiKey });
+    const res = await openai.responses.create({
+      model: 'gpt-4.1-mini',
+      temperature: 0.7,
+      input: [
+        {
+          role: 'system',
+          content:
+            'You write a single sharp follow-up question for a self-development app. Never mention AI or being a model. Never use therapy-speak.',
+        },
+        { role: 'user', content: prompt },
+      ],
+      text: {
+        format: {
+          type: 'json_schema',
+          name: 'quest_followup',
+          strict: true,
+          schema: FOLLOWUP_SCHEMA,
+        },
+      },
+    });
+
+    const text = res.output_text;
+    if (!text) return json(SKIPPED);
+
+    let parsed: Partial<Followup> | null = null;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      return json(SKIPPED);
+    }
+
+    const question = typeof parsed?.question === 'string' ? parsed.question.trim() : '';
+    const variant = parsed?.variant === 'clarify' || parsed?.variant === 'deepen' ? parsed.variant : null;
+
+    // A question without a usable variant is not worth a screen.
+    if (parsed?.skip || !question || !variant) {
+      return json(SKIPPED);
+    }
+
+    return json({ skip: false, question, variant } satisfies Followup);
+  } catch (error) {
+    console.error('generate-quest-followup error:', error);
+    // The intake treats any failure as "no follow-up", so this stays a 200.
+    return json(SKIPPED);
+  }
+});

--- a/supabase/migrations/20260809120000_add_personalized_side_quests.sql
+++ b/supabase/migrations/20260809120000_add_personalized_side_quests.sql
@@ -1,0 +1,425 @@
+-- Personalized side quest intake.
+--
+-- Captures a user's own words about what they have been avoiding, then stores
+-- LLM-generated quests written for that specific person. Generated quests live
+-- in side_quests (scoped by user_id) so that posting, feed titles, profile
+-- activity, progress counting and /quest/:id deep links keep working unchanged.
+
+-- ---------------------------------------------------------------------------
+-- Intake
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.personalized_quest_intakes (
+  id bigserial PRIMARY KEY,
+  user_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+
+  -- Raw verbatim answers. Future personalization depends on their actual
+  -- wording, so these are never overwritten with derived fields.
+  answer_avoided text,
+  answer_bail text,
+  answer_solo_experience text
+    CHECK (answer_solo_experience IN ('never', 'once_or_twice', 'regularly')),
+
+  -- Free text today. The structured columns exist so GPS or a places
+  -- autocomplete can populate them later without a migration or backfill.
+  location_raw text,
+  location_city text,
+  location_lat double precision,
+  location_lng double precision,
+  location_source text
+    CHECK (location_source IN ('manual', 'gps', 'places')),
+
+  -- NULL followup_variant means the follow-up was skipped.
+  followup_question text,
+  followup_variant text CHECK (followup_variant IN ('clarify', 'deepen')),
+  followup_answer text,
+
+  readback_lines text[] NOT NULL DEFAULT '{}'::text[],
+
+  status text NOT NULL DEFAULT 'in_progress'
+    CHECK (status IN ('in_progress', 'completed', 'abandoned')),
+  completed_at timestamptz,
+
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS personalized_quest_intakes_user_created_idx
+  ON public.personalized_quest_intakes (user_id, created_at DESC);
+
+ALTER TABLE public.personalized_quest_intakes ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "personalized_quest_intakes_select_self"
+  ON public.personalized_quest_intakes FOR SELECT
+  TO authenticated
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "personalized_quest_intakes_insert_self"
+  ON public.personalized_quest_intakes FOR INSERT
+  TO authenticated
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "personalized_quest_intakes_update_self"
+  ON public.personalized_quest_intakes FOR UPDATE
+  TO authenticated
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+-- ---------------------------------------------------------------------------
+-- side_quests: allow per-user generated rows alongside the curated pool
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE public.side_quests
+  ADD COLUMN IF NOT EXISTS user_id uuid REFERENCES public.profiles(id) ON DELETE CASCADE;
+
+ALTER TABLE public.side_quests
+  ADD COLUMN IF NOT EXISTS source text NOT NULL DEFAULT 'curated';
+
+ALTER TABLE public.side_quests
+  ADD COLUMN IF NOT EXISTS intake_id bigint
+    REFERENCES public.personalized_quest_intakes(id) ON DELETE SET NULL;
+
+ALTER TABLE public.side_quests
+  ADD COLUMN IF NOT EXISTS horizon text;
+
+ALTER TABLE public.side_quests
+  DROP CONSTRAINT IF EXISTS side_quests_source_check;
+
+ALTER TABLE public.side_quests
+  ADD CONSTRAINT side_quests_source_check
+  CHECK (source IN ('curated', 'personalized'));
+
+ALTER TABLE public.side_quests
+  DROP CONSTRAINT IF EXISTS side_quests_horizon_check;
+
+ALTER TABLE public.side_quests
+  ADD CONSTRAINT side_quests_horizon_check
+  CHECK (horizon IS NULL OR horizon IN ('today', 'weekend'));
+
+-- A curated quest belongs to nobody; a personalized quest always belongs to someone.
+ALTER TABLE public.side_quests
+  DROP CONSTRAINT IF EXISTS side_quests_source_owner_check;
+
+ALTER TABLE public.side_quests
+  ADD CONSTRAINT side_quests_source_owner_check
+  CHECK (
+    (source = 'curated' AND user_id IS NULL)
+    OR (source = 'personalized' AND user_id IS NOT NULL)
+  );
+
+CREATE INDEX IF NOT EXISTS side_quests_user_intake_idx
+  ON public.side_quests (user_id, intake_id)
+  WHERE user_id IS NOT NULL;
+
+-- Reads were previously open to every authenticated user. Personalized quests
+-- are private, but a quest referenced by an existing post must stay readable so
+-- the feed's `side_quests:quest_id (title)` join still resolves for other
+-- viewers. post_quest_id_idx supports that lookup.
+DROP POLICY IF EXISTS "side_quests_select_authenticated" ON public.side_quests;
+
+CREATE POLICY "side_quests_select_authenticated"
+  ON public.side_quests FOR SELECT
+  TO authenticated
+  USING (
+    user_id IS NULL
+    OR user_id = auth.uid()
+    OR EXISTS (
+      SELECT 1 FROM public.post p WHERE p.quest_id = side_quests.id
+    )
+  );
+
+-- ---------------------------------------------------------------------------
+-- Keep personalized quests out of the curated daily draw
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.claim_daily_side_quest(
+  ranked_quest_ids bigint[],
+  requested_local_day date
+)
+RETURNS TABLE(
+  status text,
+  draw_id bigint,
+  draw_local_day date,
+  quest jsonb
+) AS $$
+DECLARE
+  existing_draw public.side_quest_draws%ROWTYPE;
+  selected_draw public.side_quest_draws%ROWTYPE;
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'Authentication required';
+  END IF;
+
+  IF requested_local_day IS NULL THEN
+    RAISE EXCEPTION 'requested_local_day is required';
+  END IF;
+
+  SELECT *
+  INTO existing_draw
+  FROM public.side_quest_draws sqd
+  WHERE sqd.user_id = auth.uid()
+    AND sqd.local_day = requested_local_day;
+
+  IF FOUND THEN
+    RETURN QUERY
+    SELECT
+      'existing'::text,
+      existing_draw.id,
+      existing_draw.local_day,
+      to_jsonb(sq.*)
+    FROM public.side_quests sq
+    WHERE sq.id = existing_draw.quest_id;
+    RETURN;
+  END IF;
+
+  WITH ranked_candidates AS (
+    SELECT
+      sq.*,
+      ids.ordinality::int AS rank_position
+    FROM unnest(ranked_quest_ids) WITH ORDINALITY AS ids(quest_id, ordinality)
+    JOIN public.side_quests sq
+      ON sq.id = ids.quest_id
+    LEFT JOIN public.side_quest_draws seen
+      ON seen.user_id = auth.uid()
+     AND seen.quest_id = sq.id
+    WHERE sq.is_active = true
+      AND sq.user_id IS NULL
+      AND seen.id IS NULL
+  ),
+  weighted_choice AS (
+    SELECT id
+    FROM ranked_candidates
+    ORDER BY -ln(GREATEST(random(), 1e-9)) / (1.0 / rank_position)
+    LIMIT 1
+  ),
+  inserted AS (
+    INSERT INTO public.side_quest_draws (user_id, quest_id, local_day)
+    SELECT auth.uid(), id, requested_local_day
+    FROM weighted_choice
+    ON CONFLICT (user_id, local_day) DO NOTHING
+    RETURNING *
+  )
+  SELECT *
+  INTO selected_draw
+  FROM inserted;
+
+  IF FOUND THEN
+    RETURN QUERY
+    SELECT
+      'created'::text,
+      selected_draw.id,
+      selected_draw.local_day,
+      to_jsonb(sq.*)
+    FROM public.side_quests sq
+    WHERE sq.id = selected_draw.quest_id;
+    RETURN;
+  END IF;
+
+  SELECT *
+  INTO existing_draw
+  FROM public.side_quest_draws sqd
+  WHERE sqd.user_id = auth.uid()
+    AND sqd.local_day = requested_local_day;
+
+  IF FOUND THEN
+    RETURN QUERY
+    SELECT
+      'existing'::text,
+      existing_draw.id,
+      existing_draw.local_day,
+      to_jsonb(sq.*)
+    FROM public.side_quests sq
+    WHERE sq.id = existing_draw.quest_id;
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    'exhausted'::text,
+    NULL::bigint,
+    requested_local_day,
+    NULL::jsonb;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public;
+
+GRANT EXECUTE ON FUNCTION public.claim_daily_side_quest(bigint[], date) TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- prompts: allow one row per (key, locale)
+--
+-- The table already carries a locale column, a (key, locale) index and a
+-- locale argument in getPromptContent, but UNIQUE was on key alone, so a key
+-- could only ever exist in one language.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE public.prompts
+  DROP CONSTRAINT IF EXISTS prompts_key_key;
+
+ALTER TABLE public.prompts
+  DROP CONSTRAINT IF EXISTS prompts_key_locale_key;
+
+ALTER TABLE public.prompts
+  ADD CONSTRAINT prompts_key_locale_key UNIQUE (key, locale);
+
+-- ---------------------------------------------------------------------------
+-- Prompts (tuned in Supabase Studio, no deploy required)
+-- ---------------------------------------------------------------------------
+
+INSERT INTO public.prompts (key, locale, content)
+VALUES
+  (
+    'personalized_quest_followup',
+    'it',
+    'Un utente di StepnOut ha risposto a due domande.
+D1 "Cosa rimandi da mesi?": "{answer_avoided}"
+D2 "Cosa ti farebbe dare buca?": "{answer_bail}"
+
+Genera UNA sola domanda di follow-up, in italiano, dando del tu.
+
+Conta prima le parole totali di ENTRAMBE le risposte, poi applica questa regola alla lettera:
+- Meno di 10 parole in totale, OPPURE nessun luogo/persona/situazione precisa nominata -> la variante DEVE essere "clarify". Chiedi l''unico fatto concreto che manca.
+  (Esempio svolto: "palestra" + "stanco" sono 2 parole -> clarify, mai deepen.)
+- 10 parole o più E qualcosa di specifico nominato -> la variante DEVE essere "deepen". Riprendi le SUE parole e scendi di un livello su quel dettaglio.
+
+L''etichetta della variante deve rispettare la regola qui sopra anche quando la domanda che scrivi andrebbe bene per entrambe.
+
+Regole:
+- La domanda deve cambiare la quest, la sua difficoltà o il read-back. Se non lo farebbe, restituisci skip: true.
+- Chiedi un fatto o una circostanza. Mai come si sente. Mai cosa lo aiuterebbe o cosa glielo renderebbe più facile.
+- Una frase, max 100 caratteri. Nessun preambolo, nessuna empatia di servizio.'
+  ),
+  (
+    'personalized_quest_followup',
+    'en',
+    'A StepnOut user answered two questions.
+Q1 "What have you been meaning to do for months?": "{answer_avoided}"
+Q2 "What would make you bail?": "{answer_bail}"
+
+Generate ONE follow-up question in English.
+
+First count the total words across BOTH answers, then apply this rule strictly:
+- Under 10 words total, OR no specific place/person/situation named -> variant MUST be "clarify". Ask for the single missing concrete fact.
+  (Worked example: "gym" + "tired" is 2 words -> clarify, never deepen.)
+- 10 words or more AND something specific is named -> variant MUST be "deepen". Reference THEIR words and go one level down on that detail.
+
+The variant label must match the rule above even when the question you write would fit either one.
+
+Rules:
+- The question must change the quest, its difficulty, or the read-back. If it would not, return skip: true.
+- Ask about a fact or a circumstance. Never how they feel. Never what would help or make it easier.
+- One sentence, max 100 characters. No preamble, no throat-clearing empathy.'
+  ),
+  (
+    'personalized_quest_readback',
+    'it',
+    'Scrivi esattamente 3 righe brevi che nominino il vero problema di questa persona, in italiano, dando del tu.
+
+Cosa rimanda: "{answer_avoided}"
+Cosa la fa desistere: "{answer_bail}"
+Esperienza da sola: {answer_solo_experience}
+Dove vive: {location_raw}
+Follow-up: {followup_question} -> "{followup_answer}"
+
+Struttura, una riga ciascuna:
+1. Cosa si porta dietro. Parla A lui dandogli del tu. Mai ripetere la sua frase parola per parola.
+2. Il blocco, detto chiaro: quello che crede sia il problema non lo è, il problema è QUESTO.
+3. Una riformulazione che rende il problema più piccolo. Descrivilo in modo diverso — NON
+   proporre un''azione, un passo o una soluzione. La sfida arriva nella schermata dopo.
+
+Esempio svolto. Per "voglio fare un corso di ceramica da due anni" + "entrare in una stanza
+dove si conoscono già tutti", la risposta giusta è:
+Vuoi fare quel corso di ceramica da due anni.
+La ceramica non è mai stata il problema: entrare da solo lo è.
+È una cosa molto più piccola da risolvere di "non concludo mai niente".
+
+Tono: caldo e diretto, come un amico che ti ha ascoltato davvero e non sta al gioco.
+Comprensivo, mai sdolcinato, mai clinico, mai un riassunto.
+
+Regole:
+- Usa i SUOI dettagli concreti, riformulati con parole tue.
+- Max 90 caratteri a riga.
+- VIETATO: "sembra che", "ho la sensazione", "capisco", "dev''essere dura", "il vero blocco è",
+  complimenti, rassicurazioni, punti esclamativi, consigli.
+- Non fare domande. Nomina il problema, non risolverlo.'
+  ),
+  (
+    'personalized_quest_readback',
+    'en',
+    'Write exactly 3 short lines that name the real problem for this person, in English.
+
+Been avoiding: "{answer_avoided}"
+What makes them bail: "{answer_bail}"
+Solo experience: {answer_solo_experience}
+Where they live: {location_raw}
+Follow-up: {followup_question} -> "{followup_answer}"
+
+Structure, one line each:
+1. What they have been carrying. Speak TO them as "you". Never repeat their sentence back verbatim.
+2. The block, named plainly: the thing they assume is the problem is not it, THIS is.
+3. A reframe that makes the problem smaller. Describe it differently — do NOT prescribe
+   an action, a step or a fix. The challenge comes on the next screen.
+
+Worked example. For "wanted a pottery class for two years" + "walking into a room where
+everyone already knows each other", the right answer is:
+You have wanted the pottery class for two years.
+The pottery was never the problem — walking in alone is.
+That is a much smaller thing to solve than "I never follow through."
+
+Tone: warm and direct, like a friend who has been paying attention and is not going to
+pretend along with them. Understanding, never gushing, never clinical, never a summary.
+
+Rules:
+- Use THEIR concrete details, rephrased in your own words.
+- Max 90 characters per line.
+- BANNED: "it sounds like", "I hear you", "I sense", "that must be hard", "the real block is",
+  compliments, reassurance, exclamation marks, advice.
+- Ask nothing. Name the problem, do not solve it.'
+  ),
+  (
+    'personalized_quest_generation',
+    'it',
+    'Genera 2 quest per questa persona, in italiano, dando del tu.
+
+Cosa rimanda: "{answer_avoided}"
+Cosa la fa desistere: "{answer_bail}"
+Esperienza da sola: {answer_solo_experience}
+Dove vive: {location_raw}
+Follow-up: {followup_question} -> "{followup_answer}"
+
+- horizon "today": piccola, fattibile nelle prossime 24 ore, senza pianificazione.
+- horizon "weekend": quella vera, questo fine settimana, un passo concreto verso "{answer_avoided}".
+
+Regole:
+- Attacca direttamente ciò che la fa desistere ("{answer_bail}"), non aggirarlo.
+- Concreta e verificabile: si deve capire se è stata fatta o no.
+- Usa {location_raw} solo se rende la quest più fattibile.
+- title max 60 caratteri, summary max 160 caratteri.
+- Niente motivazionale generico, niente "prova a", niente emoji.
+
+Assegna i tag scegliendo SOLO fra i valori ammessi dallo schema.'
+  ),
+  (
+    'personalized_quest_generation',
+    'en',
+    'Generate 2 quests for this person, in English.
+
+Been avoiding: "{answer_avoided}"
+What makes them bail: "{answer_bail}"
+Solo experience: {answer_solo_experience}
+Where they live: {location_raw}
+Follow-up: {followup_question} -> "{followup_answer}"
+
+- horizon "today": small, doable in the next 24 hours, no planning required.
+- horizon "weekend": the real one, this coming weekend, a concrete step toward "{answer_avoided}".
+
+Rules:
+- Go straight at what makes them bail ("{answer_bail}"), do not route around it.
+- Concrete and checkable: it must be obvious whether they did it.
+- Use {location_raw} only where it makes the quest more doable.
+- title max 60 characters, summary max 160 characters.
+- No generic motivation, no "try to", no emoji.
+
+Assign tags using ONLY the values allowed by the schema.'
+  )
+ON CONFLICT (key, locale) DO UPDATE SET content = EXCLUDED.content;


### PR DESCRIPTION
## Summary

Adds an LLM-backed intake that asks a few questions in the user's own words, then generates two side quests written for that person — one for the next 24 hours, one for the weekend.

## Changes

**App**
- New intake flow at `/personalized-quest/intake` (own close button + progress bar, no global chrome, back-swipe disabled so answers aren't silently dropped)
- `personalizedQuestService`, `usePersonalizedQuestIntake`, types
- Entry point card on the side quest path
- `QuestPage` lets a user complete their own personalized quest (no draw-history entry, but still theirs)
- Italian translations + PostHog events for per-step funnel drop-off

**Backend**
- Edge functions `generate-quest-followup` and `generate-personalized-quests` (auth checked in-function via `auth.getUser()`; gateway `verify_jwt` off because it still validates with the legacy HS256 secret while the auth server issues ES256)
- Migration `20260809120000_add_personalized_side_quests.sql`: `personalized_quest_intakes` table with RLS, user-scoped columns on `side_quests`
- Curated draw pool now filters `user_id IS NULL` so personalized quests never enter it

## Notes

- Requires `OPENAI_API_KEY` in the edge runtime secrets (read from the gitignored root `.env`)
- `ios/Podfile.lock` had unrelated local pod checksum churn; left out of this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
